### PR TITLE
Some potential fixes for MSL

### DIFF
--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -89,7 +89,7 @@ class NaifSpice():
         Returns
         -------
         : str
-          The light time and abberation correction string for use in NAIF calls.
+          The light time and aberration correction string for use in NAIF calls.
           See https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html
           for the different options available.
         """

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -479,7 +479,10 @@ class Cahvor():
                                                       ephemeris_times=self.ephemeris_time,
                                                       nadir=False, exact_ck_times=False)
             cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat()
-            cahvor_rotation = ConstantRotation(cahvor_quats, self.final_inst_frame, self.sensor_frame_id)
+            #cahvor_rotation = ConstantRotation(cahvor_quats, self.final_inst_frame, self.#sensor_frame_id)
+            cahvor_rotation = ConstantRotation(cahvor_quats, self.target_frame_id,
+                                               self.sensor_frame_id)
+
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain
 

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -490,12 +490,11 @@ class Cahvor():
         #final_frame = MSL_RSM_HEAD
         final_frame = self.final_inst_frame
         if not hasattr(self, '_frame_chain'):
-            self._frame_chain \
-              = FrameChain.from_spice(sensor_frame=final_frame,
-                                      target_frame=self.target_frame_id,
-                                      center_ephemeris_time=self.center_ephemeris_time,
-                                      ephemeris_times=self.ephemeris_time,
-                                      nadir=False, exact_ck_times=False)
+            self._frame_chain = FrameChain.from_spice(sensor_frame=self.final_inst_frame,
+                                                      target_frame=self.target_frame_id,
+                                                      center_ephemeris_time=self.center_ephemeris_time,
+                                                      ephemeris_times=self.ephemeris_time,
+                                                      nadir=False, exact_ck_times=False)
               
             cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat() 
             
@@ -504,8 +503,7 @@ class Cahvor():
             if self._props.get("landed", False):
               cahvor_rotation = ConstantRotation(cahvor_quats, self.target_frame_id, self.sensor_frame_id)
             else:
-              cahvor_rotation = ConstantRotation(cahvor_quats,
-                                                 final_frame, self.sensor_frame_id)
+              cahvor_rotation = ConstantRotation(cahvor_quats, self.final_inst_frame, self.sensor_frame_id)
               
             self._frame_chain.add_edge(rotation = cahvor_rotation)
             

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -473,22 +473,14 @@ class Cahvor():
           A networkx frame chain object
         """
         if not hasattr(self, '_frame_chain'):
-            self._frame_chain = FrameChain.from_spice(sensor_frame=self.spacecraft_id * 1000,
+            self._frame_chain = FrameChain.from_spice(sensor_frame=self.final_inst_frame,
                                                       target_frame=self.target_frame_id,
                                                       center_ephemeris_time=self.center_ephemeris_time,
                                                       ephemeris_times=self.ephemeris_time,
                                                       nadir=False, exact_ck_times=False)
-
-            # Extra temporary rotation in the rover frame
-            C1 = np.array([[6.80577524e-01, -9.11460527e-03,  7.32619382e-01],
-                            [ 7.32652737e-01,  4.81672679e-04, -6.80602479e-01],
-                            [ 5.85055122e-03,  9.99958359e-01,  7.00565704e-03]])
-            transformed_cahv = np.matmul(self.cahvor_rotation_matrix, C1)
-            cahvor_quats = Rotation.from_matrix(transformed_cahv).as_quat()
-
-            cahvor_rotation = ConstantRotation(cahvor_quats, self.spacecraft_id * 1000,
-                                               self.sensor_frame_id)
-
+            cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix)
+            quats = cahvor_quats.as_quat()
+            cahvor_rotation = ConstantRotation(quats, self.final_inst_frame, self.sensor_frame_id)
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain
 

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -463,10 +463,6 @@ class Cahvor():
         return self._cahvor_rotation_matrix
 
     @property
-    def cahvor_X(self):
-        return self.X
-
-    @property
     def cahvor_center(self):
         """
         Computes the cahvor center for the instrument to Rover frame
@@ -478,6 +474,23 @@ class Cahvor():
         """
         return self.cahvor_camera_dict['C']  
     
+    @property
+    def rover_frame_rotation(self):
+        """
+        Estimate the rotation X in the rover coordinates, such that the transform
+        from Mars ECEF coordinates to camera coordinates is given by
+        cahvor_rotation * X * EcefToRover
+        """
+
+        # Experiment with adjusting the rover to camera rotation. Need to look 
+        # at the MSL NAIF documentation and find the right way to do this.
+        r = Rotation.from_euler("zyx", [20, -20, 20], degrees=True)
+        X = "-0.13005758  0.79616099  0.59095196 -0.46804661 -0.57473784  0.67126629  0.87404766 -0.1893059   0.44742102"
+        X = np.array(X.split(),  dtype=np.float64)
+        X = X.reshape(3, 3)
+        X = np.matmul(r.as_matrix(), X)
+        return X
+
     @property
     def frame_chain(self):
         """
@@ -496,76 +509,9 @@ class Cahvor():
                                                       ephemeris_times=self.ephemeris_time,
                                                       nadir=False, exact_ck_times=False)
 
-            #print("Euler angles before\n", Rotation.from_matrix(self.cahvor_rotation_matrix).as_euler("zyx", degrees=True))
-            # Print determinant of the cahvor rotation matrix
-            print("Determinant of cahvor rotation matrix: ", np.linalg.det(self.cahvor_rotation_matrix))
-            #Q = np.linalg.inv(self.cahvor_rotation_matrix).flatten()
-            # print q with comma-separated values
-
-            #print("---inv cahvore matrix before", Q)
-            # print Q with comma as separator
-            #print("---inv cahvore matrix before", ",".join(map(str, Q)))
-
-
-            # Apply an artifical 90 degree rotation about the z axis to the cahvor model       
-            # Angles below: move left, move down, roll 
-            #r = Rotation.from_euler("zyx", [-50, -90, 170], degrees=True) # reference
-            #r = Rotation.from_euler("zyx", [-60, -90, 170], degrees=True) # better
-            #r = Rotation.from_euler("zyx", [-80, -90, 170], degrees=True) # w5
-            #r = Rotation.from_euler("zyx", [-80, -95, 165], degrees=True) # w6
-            #r = Rotation.from_euler("zyx", [-80, -90, 155], degrees=True) # w7
-            #r = Rotation.from_euler("zyx", [-80, -90, 145], degrees=True) # w8 # pretty good
-            #r = Rotation.from_euler("zyx", [-80, -80, 145], degrees=True) # w2 # better
-            #r = Rotation.from_euler("zyx", [-80, -70, 145], degrees=True) # w3
-            #r = Rotation.from_euler("zyx", [-80, -70, 135], degrees=True) # w4 better
-            r = Rotation.from_euler("zyx", [-85, -70, 135], degrees=True) # w5 better
-            r = Rotation.from_euler("zyx", [-85, -60, 135], degrees=True) # w6
-            r = Rotation.from_euler("zyx", [-85, -50, 135], degrees=True) # w7 better
-            r = Rotation.from_euler("zyx", [-85, -50, 125], degrees=True) # w8 better
-            r = Rotation.from_euler("zyx", [-85, -50, 115], degrees=True) # w9 better
-            r = Rotation.from_euler("zyx", [-90, -50, 115], degrees=True) # w1 better
-            r = Rotation.from_euler("zyx", [-100, -50, 115], degrees=True) # w2 better
-            r = Rotation.from_euler("zyx", [-110, -50, 115], degrees=True) # w3 better
-            r = Rotation.from_euler("zyx", [-110, -40, 115], degrees=True) # w4 better
-            r = Rotation.from_euler("zyx", [-110, -30, 115], degrees=True) # w5 better
-            r = Rotation.from_euler("zyx", [-110, -30, 105], degrees=True) # w6
-            r = Rotation.from_euler("zyx", [-110, -30, 95], degrees=True) # w7
-            r = Rotation.from_euler("zyx", [-120, -30, 95], degrees=True) # w8 better
-            r = Rotation.from_euler("zyx", [-130, -30, 95], degrees=True) # w9
-            r = Rotation.from_euler("zyx", [-130, -30, 85], degrees=True) # w1 better
-            r = Rotation.from_euler("zyx", [-140, -30, 85], degrees=True) # w2
-            r = Rotation.from_euler("zyx", [-140, -35, 85], degrees=True) # w3 better
-            r = Rotation.from_euler("zyx", [-150, -35, 85], degrees=True) # w4
-            r = Rotation.from_euler("zyx", [0, 0, 0], degrees=True) # w5 better
-            r = Rotation.from_euler("zyx", [0, -15, 0], degrees=True) # good
-            r = Rotation.from_euler("zyx", [0, -20, 0], degrees=True) # good
-            r = Rotation.from_euler("zyx", [10, -20, 10], degrees=True) # good #v6
-            r = Rotation.from_euler("zyx", [10, -20, 20], degrees=True) # v7 beter
-            r = Rotation.from_euler("zyx", [50, -20, 20], degrees=True) # v1
-            r = Rotation.from_euler("zyx", [10, -20, 20], degrees=True) # v2
-            r = Rotation.from_euler("zyx", [20, -20, 20], degrees=True) # v3 # better
-
-            # Print flattened T
-            X = "-0.13005758  0.79616099  0.59095196 -0.46804661 -0.57473784  0.67126629  0.87404766 -0.1893059   0.44742102"
-            X = np.array(X.split(),  dtype=np.float64)
-            X = X.reshape(3, 3)
-            #X = np.matmul(X, r.as_matrix()) # works better than below?
-            #X = np.matmul(np.linalg.inv(r.as_matrix()), X)
-            X = np.matmul(r.as_matrix(), X)
-            self.X = X
-            #M = np.matmul(self.cahvor_rotation_matrix, X)
-            M = self.cahvor_rotation_matrix
-
-            #self.cahvor_rotation_matrix
-            print("cahcovr rotation matrix before\n", M)
-            #cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat() 
-            cahvor_quats = Rotation.from_matrix(M).as_quat() 
-            #print("--temporary!!!--")
-            #cahvor_quats = [0, 0, 0, 1]
+            cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat() 
             cahvor_rotation = ConstantRotation(cahvor_quats, 
                                                self.target_frame_id, self.sensor_frame_id)
-            print("cahvor_rotation after\n", cahvor_rotation.rotation_matrix())
-            #print("Euler angles after\n", Rotation.from_matrix(C).as_euler("zyx", degrees=True))
 
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -451,7 +451,7 @@ class Cahvor():
             v_s = self.compute_v_s()
             H_prime = (self.cahvor_camera_dict['H'] - h_c * self.cahvor_camera_dict['A'])/h_s
             V_prime = (self.cahvor_camera_dict['V'] - v_c * self.cahvor_camera_dict['A'])/v_s
-            self._cahvor_rotation_matrix = np.array([H_prime, -V_prime, -self.cahvor_camera_dict['A']])
+            self._cahvor_rotation_matrix = np.array([-H_prime, V_prime, -self.cahvor_camera_dict['A']])
         return self._cahvor_rotation_matrix
 
     @property
@@ -487,7 +487,9 @@ class Cahvor():
         : float
           The detector center line/boresight center line
         """
-        return self.compute_v_c()
+        # Add here 0.5 for consistency with the CSM convention that the
+        # upper-left image pixel is at (0.5, 0.5).
+        return self.compute_v_c() + 0.5
 
     @property
     def detector_center_sample(self):
@@ -500,7 +502,9 @@ class Cahvor():
         : float
           The detector center sample/boresight center sample
         """
-        return self.compute_h_c()
+        # Add here 0.5 for consistency with the CSM convention that the
+        # upper-left image pixel is at (0.5, 0.5).
+        return self.compute_h_c() + 0.5
 
     @property
     def pixel_size(self):

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -386,6 +386,13 @@ class Cahvor():
         """
         raise NotImplementedError
 
+    @property
+    def final_inst_frame(self):
+      """
+      Defines the final frame before cahvor frame in the frame chain
+      """
+      raise NotImplementedError
+
     def compute_h_c(self):
         """
         Computes the h_c element of a cahvor model for the conversion

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -504,40 +504,30 @@ class Cahvor():
         : object
           A networkx frame chain object
         """
+        MSL_ROVER  = -76000   # rover frame (way before cahvor frame) 
+        MSL_RSM_HEAD = -76205 # final frame before cahvor frame
+        #final_frame = MSL_RSM_HEAD
+        final_frame = MSL_ROVER
         if not hasattr(self, '_frame_chain'):
             self._frame_chain \
-              = FrameChain.from_spice(#sensor_frame=self.spacecraft_id * 1000,
-                                      sensor_frame=self.final_inst_frame,
+              = FrameChain.from_spice(sensor_frame=final_frame,
                                       target_frame=self.target_frame_id,
                                       center_ephemeris_time=self.center_ephemeris_time,
                                       ephemeris_times=self.ephemeris_time,
                                       nadir=False, exact_ck_times=False)
               
-            #print("target frame is ", self.target_frame_id, "=", spice.frmnam(self.target_frame_id))  
-            
             cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat() 
             # use instead the identity
-            #print("--temporarily using identity matrix for cahvor rotation")
             #cahvor_quats = Rotation.from_matrix(np.identity(3)).as_quat()
-            #cahvor_rotation = ConstantRotation(cahvor_quats, 
-            #                                   self.target_frame_id, self.sensor_frame_id)
             
-            # If we are landed we only care about the final cahvor frame relative to the target
+            # If we are landed we only care about the final cahvor frame
+            # relative to the target
             if self._props.get("landed", False):
               cahvor_rotation = ConstantRotation(cahvor_quats, self.target_frame_id, self.sensor_frame_id)
             else:
-              #cahvor_rotation = ConstantRotation(cahvor_quats, self.target_frame_id, self.sensor_frame_id)
-              s = self.final_inst_frame # MSL_RSM_HEAD
-              d = self.sensor_frame_id
               #print("should s and d be reversed here?")
-              print("++--constant rot s =", s, '=', spice.frmnam(s), "d=", d, '=', spice.frmnam(d))
-              cahvor_rotation = ConstantRotation(cahvor_quats, self.final_inst_frame, self.sensor_frame_id)
-              
-              print("----------temporary2")
-              print("1sensor frame is ", self.sensor_frame_id)
-              MSL_ROVER  = -76000 
-              cahvor_rotation = ConstantRotation(cahvor_quats, MSL_ROVER, 
-                                                 self.sensor_frame_id)
+              cahvor_rotation = ConstantRotation(cahvor_quats,
+                                                 final_frame, self.sensor_frame_id)
               
             self._frame_chain.add_edge(rotation = cahvor_rotation)
             

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -478,9 +478,8 @@ class Cahvor():
                                                       center_ephemeris_time=self.center_ephemeris_time,
                                                       ephemeris_times=self.ephemeris_time,
                                                       nadir=False, exact_ck_times=False)
-            cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix)
-            quats = cahvor_quats.as_quat()
-            cahvor_rotation = ConstantRotation(quats, self.final_inst_frame, self.sensor_frame_id)
+            cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat()
+            cahvor_rotation = ConstantRotation(cahvor_quats, self.final_inst_frame, self.sensor_frame_id)
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain
 

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -451,7 +451,7 @@ class Cahvor():
             v_s = self.compute_v_s()
             H_prime = (self.cahvor_camera_dict['H'] - h_c * self.cahvor_camera_dict['A'])/h_s
             V_prime = (self.cahvor_camera_dict['V'] - v_c * self.cahvor_camera_dict['A'])/v_s
-            self._cahvor_rotation_matrix = np.array([-H_prime, V_prime, -self.cahvor_camera_dict['A']])
+            self._cahvor_rotation_matrix = np.array([H_prime, -V_prime, self.cahvor_camera_dict['A']])
         return self._cahvor_rotation_matrix
 
     @property

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -1,8 +1,9 @@
 import math
 
 import numpy as np
+import os
 from scipy.spatial.transform import Rotation
-
+import scipy.spatial.transform.rotation as rot
 from ale.transformation import FrameChain
 from ale.transformation import ConstantRotation
 
@@ -462,6 +463,22 @@ class Cahvor():
         return self._cahvor_rotation_matrix
 
     @property
+    def cahvor_X(self):
+        return self.X
+
+    @property
+    def cahvor_center(self):
+        """
+        Computes the cahvor center for the instrument to Rover frame
+
+        Returns
+        -------
+        : array
+          Cahvor center as a 1D numpy array
+        """
+        return self.cahvor_camera_dict['C']  
+    
+    @property
     def frame_chain(self):
         """
         Returns a modified frame chain with the cahvor models extra rotation
@@ -473,15 +490,82 @@ class Cahvor():
           A networkx frame chain object
         """
         if not hasattr(self, '_frame_chain'):
-            self._frame_chain = FrameChain.from_spice(sensor_frame=self.final_inst_frame,
+            self._frame_chain = FrameChain.from_spice(sensor_frame=self.spacecraft_id * 1000,
                                                       target_frame=self.target_frame_id,
                                                       center_ephemeris_time=self.center_ephemeris_time,
                                                       ephemeris_times=self.ephemeris_time,
                                                       nadir=False, exact_ck_times=False)
-            cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat()
-            #cahvor_rotation = ConstantRotation(cahvor_quats, self.final_inst_frame, self.#sensor_frame_id)
-            cahvor_rotation = ConstantRotation(cahvor_quats, self.target_frame_id,
-                                               self.sensor_frame_id)
+
+            #print("Euler angles before\n", Rotation.from_matrix(self.cahvor_rotation_matrix).as_euler("zyx", degrees=True))
+            # Print determinant of the cahvor rotation matrix
+            print("Determinant of cahvor rotation matrix: ", np.linalg.det(self.cahvor_rotation_matrix))
+            #Q = np.linalg.inv(self.cahvor_rotation_matrix).flatten()
+            # print q with comma-separated values
+
+            #print("---inv cahvore matrix before", Q)
+            # print Q with comma as separator
+            #print("---inv cahvore matrix before", ",".join(map(str, Q)))
+
+
+            # Apply an artifical 90 degree rotation about the z axis to the cahvor model       
+            # Angles below: move left, move down, roll 
+            #r = Rotation.from_euler("zyx", [-50, -90, 170], degrees=True) # reference
+            #r = Rotation.from_euler("zyx", [-60, -90, 170], degrees=True) # better
+            #r = Rotation.from_euler("zyx", [-80, -90, 170], degrees=True) # w5
+            #r = Rotation.from_euler("zyx", [-80, -95, 165], degrees=True) # w6
+            #r = Rotation.from_euler("zyx", [-80, -90, 155], degrees=True) # w7
+            #r = Rotation.from_euler("zyx", [-80, -90, 145], degrees=True) # w8 # pretty good
+            #r = Rotation.from_euler("zyx", [-80, -80, 145], degrees=True) # w2 # better
+            #r = Rotation.from_euler("zyx", [-80, -70, 145], degrees=True) # w3
+            #r = Rotation.from_euler("zyx", [-80, -70, 135], degrees=True) # w4 better
+            r = Rotation.from_euler("zyx", [-85, -70, 135], degrees=True) # w5 better
+            r = Rotation.from_euler("zyx", [-85, -60, 135], degrees=True) # w6
+            r = Rotation.from_euler("zyx", [-85, -50, 135], degrees=True) # w7 better
+            r = Rotation.from_euler("zyx", [-85, -50, 125], degrees=True) # w8 better
+            r = Rotation.from_euler("zyx", [-85, -50, 115], degrees=True) # w9 better
+            r = Rotation.from_euler("zyx", [-90, -50, 115], degrees=True) # w1 better
+            r = Rotation.from_euler("zyx", [-100, -50, 115], degrees=True) # w2 better
+            r = Rotation.from_euler("zyx", [-110, -50, 115], degrees=True) # w3 better
+            r = Rotation.from_euler("zyx", [-110, -40, 115], degrees=True) # w4 better
+            r = Rotation.from_euler("zyx", [-110, -30, 115], degrees=True) # w5 better
+            r = Rotation.from_euler("zyx", [-110, -30, 105], degrees=True) # w6
+            r = Rotation.from_euler("zyx", [-110, -30, 95], degrees=True) # w7
+            r = Rotation.from_euler("zyx", [-120, -30, 95], degrees=True) # w8 better
+            r = Rotation.from_euler("zyx", [-130, -30, 95], degrees=True) # w9
+            r = Rotation.from_euler("zyx", [-130, -30, 85], degrees=True) # w1 better
+            r = Rotation.from_euler("zyx", [-140, -30, 85], degrees=True) # w2
+            r = Rotation.from_euler("zyx", [-140, -35, 85], degrees=True) # w3 better
+            r = Rotation.from_euler("zyx", [-150, -35, 85], degrees=True) # w4
+            r = Rotation.from_euler("zyx", [0, 0, 0], degrees=True) # w5 better
+            r = Rotation.from_euler("zyx", [0, -15, 0], degrees=True) # good
+            r = Rotation.from_euler("zyx", [0, -20, 0], degrees=True) # good
+            r = Rotation.from_euler("zyx", [10, -20, 10], degrees=True) # good #v6
+            r = Rotation.from_euler("zyx", [10, -20, 20], degrees=True) # v7 beter
+            r = Rotation.from_euler("zyx", [50, -20, 20], degrees=True) # v1
+            r = Rotation.from_euler("zyx", [10, -20, 20], degrees=True) # v2
+            r = Rotation.from_euler("zyx", [20, -20, 20], degrees=True) # v3 # better
+
+            # Print flattened T
+            X = "-0.13005758  0.79616099  0.59095196 -0.46804661 -0.57473784  0.67126629  0.87404766 -0.1893059   0.44742102"
+            X = np.array(X.split(),  dtype=np.float64)
+            X = X.reshape(3, 3)
+            #X = np.matmul(X, r.as_matrix()) # works better than below?
+            #X = np.matmul(np.linalg.inv(r.as_matrix()), X)
+            X = np.matmul(r.as_matrix(), X)
+            self.X = X
+            #M = np.matmul(self.cahvor_rotation_matrix, X)
+            M = self.cahvor_rotation_matrix
+
+            #self.cahvor_rotation_matrix
+            print("cahcovr rotation matrix before\n", M)
+            #cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat() 
+            cahvor_quats = Rotation.from_matrix(M).as_quat() 
+            #print("--temporary!!!--")
+            #cahvor_quats = [0, 0, 0, 1]
+            cahvor_rotation = ConstantRotation(cahvor_quats, 
+                                               self.target_frame_id, self.sensor_frame_id)
+            print("cahvor_rotation after\n", cahvor_rotation.rotation_matrix())
+            #print("Euler angles after\n", Rotation.from_matrix(C).as_euler("zyx", degrees=True))
 
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -106,7 +106,6 @@ def load(label, props={}, formatter='ale', verbose=False, only_isis_spice=False,
     dict
          The ISD as a dictionary
     """
-    print("Banana", only_isis_spice, only_naif_spice)
     if isinstance(formatter, str):
         formatter = __formatters__[formatter]
     

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -186,7 +186,6 @@ def loads(label, props='', formatter='ale', indent = 2, verbose=False, only_isis
     --------
     load
     """
-    print(only_isis_spice, only_naif_spice)
     res = load(label, props, formatter, verbose, only_isis_spice, only_naif_spice)
     return json.dumps(res, indent=indent, cls=AleJsonEncoder)
 

--- a/ale/drivers/co_drivers.py
+++ b/ale/drivers/co_drivers.py
@@ -205,7 +205,7 @@ class CassiniIssIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, RadialDis
         """
         NAC uses multiple filter pairs, each filter combination has a different focal length.
         NAIF's Cassini kernels do not contain focal lengths for NAC filters and
-        so we aquired updated NAC filter data from ISIS's IAK kernel.
+        so we acquired updated NAC filter data from ISIS's IAK kernel.
 
         """
         # default focal defined by IAK kernel
@@ -277,11 +277,12 @@ class CassiniIssIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, RadialDis
                 _ = spice.frinfo(self.sensor_frame_id)
                 self._frame_chain = super().frame_chain
             except spice.utils.exceptions.NotFoundError as e:
-                self._frame_chain = FrameChain.from_spice(sensor_frame=self._original_naif_sensor_frame_id,
-                                                          target_frame=self.target_frame_id,
-                                                          center_ephemeris_time=self.center_ephemeris_time,
-                                                          ephemeris_times=self.ephemeris_time,
-                                                          exact_ck_times=True)
+                self._frame_chain = \
+                FrameChain.from_spice(sensor_frame=self._original_naif_sensor_frame_id,
+                                      target_frame=self.target_frame_id,
+                                      center_ephemeris_time=self.center_ephemeris_time,
+                                      ephemeris_times=self.ephemeris_time,
+                                      exact_ck_times=True)
 
                 rotation = ConstantRotation([[0, 0, 1, 0]], self.sensor_frame_id, self._original_naif_sensor_frame_id)
 
@@ -506,11 +507,12 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
                 _ = spice.frinfo(self.sensor_frame_id)
                 self._frame_chain = super().frame_chain
             except spice.utils.exceptions.NotFoundError as e:
-                self._frame_chain = FrameChain.from_spice(sensor_frame=self._original_naif_sensor_frame_id,
-                                                          target_frame=self.target_frame_id,
-                                                          center_ephemeris_time=self.center_ephemeris_time,
-                                                          ephemeris_times=self.ephemeris_time,
-                                                          exact_ck_times=True)
+                self._frame_chain = \
+                FrameChain.from_spice(sensor_frame=self._original_naif_sensor_frame_id,
+                                      target_frame=self.target_frame_id,
+                                      center_ephemeris_time=self.center_ephemeris_time,
+                                      ephemeris_times=self.ephemeris_time,
+                                      exact_ck_times=True)
 
                 rotation = ConstantRotation([[0, 0, 1, 0]], self.sensor_frame_id, self._original_naif_sensor_frame_id)
 

--- a/ale/drivers/lro_drivers.py
+++ b/ale/drivers/lro_drivers.py
@@ -102,7 +102,7 @@ class LroLrocNacPds3LabelNaifSpiceDriver(LineScanner, NaifSpice, Pds3Label, Driv
     @property
     def light_time_correction(self):
         """
-        Returns the type of light time correction and abberation correction to
+        Returns the type of light time correction and aberration correction to
         use in NAIF calls.
 
         LROC is specifically set to not use light time correction because it is
@@ -112,7 +112,7 @@ class LroLrocNacPds3LabelNaifSpiceDriver(LineScanner, NaifSpice, Pds3Label, Driv
         Returns
         -------
         : str
-          The light time and abberation correction string for use in NAIF calls.
+          The light time and aberration correction string for use in NAIF calls.
           See https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html
           for the different options available.
         """

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -81,6 +81,7 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : int
           Naif frame code for MSL_RSM_HEAD
         """
+        print("----final inst frame is ", spice.bods2c("MSL_RSM_HEAD"))
         return spice.bods2c("MSL_RSM_HEAD")
 
     @property
@@ -98,6 +99,7 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         if not hasattr(self, "_site_frame_id"):
           site_frame = "MSL_SITE_" + str(self.label["GEOMETRIC_CAMERA_MODEL_PARMS"]["REFERENCE_COORD_SYSTEM_INDEX"][0])
           self._site_frame_id= spice.bods2c(site_frame)
+        print("----sensor frame id is ", self._site_frame_id)
         return self._site_frame_id
 
     @property

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -96,7 +96,7 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector lines
         """
-        return [0, 1/self.pixel_size, 0]
+        return [0, 0, 1/self.pixel_size]
     
     @property
     def focal2pixel_samples(self):
@@ -108,23 +108,23 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector samples
         """
-        return [0, 0, 1/self.pixel_size]
+        return [0, 1/self.pixel_size, 0]
 
-    @property
-    def detector_center_line(self):
-        return self.label["INSTRUMENT_STATE_PARMS"]["DETECTOR_LINES"]/2
-
-    @property
-    def detector_center_sample(self):
-        return self.label["INSTRUMENT_STATE_PARMS"]["MSL:DETECTOR_SAMPLES"]/2
+    # The detector_center_line() and detector_center_sample()
+    # functions from Cahvor() will be invoked. There is no need to
+    # reimplement them here.
 
     @property
     def detector_start_line(self):
-        return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE"]
+        # Do not return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE"]
+        # The value 0 is consistent with the Cahvor camera model.
+        return 0
 
     @property
     def detector_start_sample(self):
-        return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE_SAMPLE"]
+        # Do not return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE_SAMPLE"])
+        # The value 0 is consistent with the Cahvor camera model.
+        return 0
 
     @property
     def sensor_model_version(self):

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -42,7 +42,9 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         """
         lookup = {
           "MAST_RIGHT": 'MASTCAM_RIGHT',
-          "MAST_LEFT": 'MASTCAM_LEFT'
+          "MAST_LEFT": 'MASTCAM_LEFT',
+          "NAV_LEFT_B": 'MASTCAM_LEFT',
+          "NAV_RIGHT_B": 'MASTCAM_RIGHT'
         }
         return self.instrument_host_id + "_" + lookup[super().instrument_id]
 
@@ -108,7 +110,10 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector lines
         """
-        return [0, 0, 1/self.pixel_size]
+        #return [0, 1/self.pixel_size, 0] # test
+        return [0, 0, -1/self.pixel_size]
+    
+    
     
     @property
     def focal2pixel_samples(self):
@@ -120,8 +125,9 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector samples
         """
-        return [0, 1/self.pixel_size, 0]
-
+        #return [0, 0, 1/self.pixel_size] # test
+        return [0, -1/self.pixel_size, 0]
+    
     # The detector_center_line() and detector_center_sample()
     # functions from Cahvor() will be invoked. There is no need to
     # reimplement them here.

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -166,3 +166,37 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
           for the different options available.
         """
         return 'NONE'
+        
+    @property
+    def sensor_position(self):
+        """
+        Find the rover position, then add the camera position relative to the
+        rover. The returned position is in ECEF.
+        
+        Returns
+        -------
+        : (positions, velocities, times)
+          a tuple containing a list of positions, a list of velocities, and a
+          list of times.
+        """
+        
+        # Rover position in ECEF    
+        positions, velocities, times = super().sensor_position
+
+        # Rover-to-camera offset in rover frame
+        cam_ctr = self.cahvor_center
+        
+        # Rover-to-camera offset in ECEF
+        ecef_frame  = self.target_frame_id        
+        rover_frame = self.final_inst_frame
+        frame_chain = self.frame_chain
+        rover2ecef_rotation = \
+          frame_chain.compute_rotation(rover_frame, ecef_frame)
+        cam_ctr = rover2ecef_rotation.apply_at([cam_ctr], times)[0]
+
+        # Go from rover position to camera position
+        positions[0] += cam_ctr
+
+        return positions, velocities, times
+      
+

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -74,15 +74,14 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
     @property
     def final_inst_frame(self):
         """
-        Defines MSLs last naif frame before the cahvor model frame
+        Defines the MSL naif frame relative to which the cahvor model is defined.
 
         Returns
         -------
         : int
-          Naif frame code for MSL_RSM_HEAD
+          Naif frame code for MSL_ROVER
         """
-        print("----final inst frame is ", spice.bods2c("MSL_RSM_HEAD"))
-        return spice.bods2c("MSL_RSM_HEAD")
+        return spice.bods2c("MSL_ROVER")
 
     @property
     def sensor_frame_id(self):
@@ -99,7 +98,6 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         if not hasattr(self, "_site_frame_id"):
           site_frame = "MSL_SITE_" + str(self.label["GEOMETRIC_CAMERA_MODEL_PARMS"]["REFERENCE_COORD_SYSTEM_INDEX"][0])
           self._site_frame_id= spice.bods2c(site_frame)
-        print("----sensor frame id is ", self._site_frame_id)
         return self._site_frame_id
 
     @property
@@ -112,10 +110,7 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector lines
         """
-        #return [0, 1/self.pixel_size, 0] # test
         return [0, 0, -1/self.pixel_size]
-    
-    
     
     @property
     def focal2pixel_samples(self):
@@ -127,7 +122,6 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector samples
         """
-        #return [0, 0, 1/self.pixel_size] # test
         return [0, -1/self.pixel_size, 0]
     
     # The detector_center_line() and detector_center_sample()
@@ -155,3 +149,20 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
           ISIS sensor model version
         """
         return 1
+
+    @property
+    def light_time_correction(self):
+        """
+        Returns the type of light time correction and aberration correction to
+        use in NAIF calls.
+
+        For MSL using such a correction returns wrong results, so turn it off.
+        
+        Returns
+        -------
+        : str
+          The light time and aberration correction string for use in NAIF calls.
+          See https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html
+          for the different options available.
+        """
+        return 'NONE'

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -70,6 +70,18 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         return self._cahvor_camera_params
 
     @property
+    def final_inst_frame(self):
+        """
+        Defines MSLs last naif frame before the cahvor model frame
+
+        Returns
+        -------
+        : int
+          Naif frame code for MSL_RSM_HEAD
+        """
+        return spice.bods2c("MSL_RSM_HEAD")
+
+    @property
     def sensor_frame_id(self):
         """
         Returns the Naif ID code for the site reference frame

--- a/ale/formatters/formatter.py
+++ b/ale/formatters/formatter.py
@@ -102,7 +102,7 @@ def to_isd(driver):
         # (destination, intermediate, ..., intermediate, source)
         body_rotation['time_dependent_frames'] \
             = shortest_path(frame_chain, source_frame, J2000)
-        time_dependent_rotation = frame_chain.compute_rotation(J200, source_frame)
+        time_dependent_rotation = frame_chain.compute_rotation(J2000, source_frame)
         body_rotation['ck_table_start_time'] = time_dependent_rotation.times[0]
         body_rotation['ck_table_end_time'] = time_dependent_rotation.times[-1]
         body_rotation['ck_table_original_size'] = len(time_dependent_rotation.times)

--- a/ale/formatters/formatter.py
+++ b/ale/formatters/formatter.py
@@ -1,6 +1,7 @@
 import json, os
 import numpy as np
 from scipy.interpolate import interp1d, BPoly
+import spiceypy as spice
 
 from networkx.algorithms.shortest_paths.generic import shortest_path
 
@@ -92,19 +93,26 @@ def to_isd(driver):
 
     body_rotation = {}
     source_frame, destination_frame, time_dependent_target_frame = frame_chain.last_time_dependent_frame_between(target_frame, 1)
-
+    print("source frame is ", source_frame, spice.frmnam(source_frame)) 
+    print("destination frame is ", destination_frame, spice.frmnam(destination_frame))
+    
+    IAU_MARS = 10014 # frame
+    J2000 = 1 # frame
     EcefToRover = []
     if source_frame != 1:
         # Reverse the frame order because ISIS orders frames as
         # (destination, intermediate, ..., intermediate, source)
         body_rotation['time_dependent_frames'] = shortest_path(frame_chain, source_frame, 1)
         print("--compute rotation from 1 to source_frame")
+        # Below is compute_rotation(J2000, IAU_MARS) from J2000 to IAU_MARS
         time_dependent_rotation = frame_chain.compute_rotation(1, source_frame)
         body_rotation['ck_table_start_time'] = time_dependent_rotation.times[0]
         body_rotation['ck_table_end_time'] = time_dependent_rotation.times[-1]
         body_rotation['ck_table_original_size'] = len(time_dependent_rotation.times)
         body_rotation['ephemeris_times'] = time_dependent_rotation.times
         body_rotation['quaternions'] = time_dependent_rotation.quats[:, [3, 0, 1, 2]]
+        #print("--temporary 1")
+        #body_rotation['quaternions'] = [[0, 0, 0, 1]]
         body_rotation['angular_velocities'] = time_dependent_rotation.av
 
         # Find the rotation from ECEF to the rover frame
@@ -113,13 +121,11 @@ def to_isd(driver):
         #time_dependent_rotation = frame_chain.compute_rotation(-76000, 10014)
         #time_dependent_rotation = frame_chain.compute_rotation(10014, -76205)
         #time_dependent_rotation = frame_chain.compute_rotation(-76205, 10014)
-        EcefToRover = Rotation.from_quat(time_dependent_rotation.quats).as_matrix()
+        #EcefToRover = Rotation.from_quat(time_dependent_rotation.quats).as_matrix()
         #print("Unadjusted EcefToRover is ", EcefToRover)
         # It was found empirically that an additional rotation is needed
         # TODO(oalexan1): Must read the NAIF doc and do an honest job.
-        print("--temporary2")
-        EcefToRover = np.matmul(driver.rover_frame_rotation, EcefToRover)
-        print("--temporary3")
+        #EcefToRover = np.matmul(driver.rover_frame_rotation, EcefToRover)
 
     if source_frame != target_frame:
         print("----will reverse the frame order")
@@ -131,23 +137,26 @@ def to_isd(driver):
     else:
         print("----will not reverse the frame order")
 
-    print("--now here 11")
     body_rotation["reference_frame"] = destination_frame
     meta_data['body_rotation'] = body_rotation
-    print("--now here 12")
 
     # sensor orientation
-    print("--now here 13")
     sensor_frame = driver.sensor_frame_id
-    print("--now here 14")
     instrument_pointing = {}
     source_frame, destination_frame, time_dependent_sensor_frame = frame_chain.last_time_dependent_frame_between(1, sensor_frame)
-    print("--now here 15")
-
+    
+    print("----------temporary1")
+    MSL_ROVER  = -76000 
+    destination_frame = MSL_ROVER
+    
     # Reverse the frame order because ISIS orders frames as
     # (destination, intermediate, ..., intermediate, source)
-    print("--now here 6")
     instrument_pointing['time_dependent_frames'] = shortest_path(frame_chain, destination_frame, 1)
+    #print("destination frame is ", destination_frame, spice.frmnam(destination_frame))
+    # destination frame is MSL_RSM_EL
+    # source frame is MSL_RSM_ZERO_EL
+    # print source frame
+    #print("4source frame is ", source_frame, spice.frmnam(source_frame))
     time_dependent_rotation = frame_chain.compute_rotation(1, destination_frame)
     instrument_pointing['ck_table_start_time'] = time_dependent_rotation.times[0]
     instrument_pointing['ck_table_end_time'] = time_dependent_rotation.times[-1]
@@ -155,7 +164,8 @@ def to_isd(driver):
     instrument_pointing['ephemeris_times'] = time_dependent_rotation.times
     instrument_pointing['quaternions'] = time_dependent_rotation.quats[:, [3, 0, 1, 2]]
     instrument_pointing['angular_velocities'] = time_dependent_rotation.av
-
+    #print("--temporary 5")
+    #instrument_pointing['quaternions'] = [[0, 0, 0, 1]]
     # reference frame should be the last frame in the chain
     instrument_pointing["reference_frame"] = instrument_pointing['time_dependent_frames'][-1]
 
@@ -181,17 +191,22 @@ def to_isd(driver):
         meta_data['starting_detector_sample'] = driver.detector_start_sample
 
     j2000_rotation = frame_chain.compute_rotation(target_frame, 1)
-    print("--now here 5")    
     # Reverse the frame order because ISIS orders frames as
     # (destination, intermediate, ..., intermediate, source)
     instrument_pointing['constant_frames'] = shortest_path(frame_chain, sensor_frame, destination_frame)
     # Find rotation from ECEF to camera. See rover_frame_rotation() for an explanation.
-    roverToCamera = driver.cahvor_rotation_matrix
-    EcefToCamera = np.matmul(roverToCamera, EcefToRover)
-    instrument_pointing['constant_rotation'] = EcefToCamera.flatten()
-    print("--now here 6")
-    #constant_rotation = frame_chain.compute_rotation(destination_frame, sensor_frame)
-    #instrument_pointing['constant_rotation'] = constant_rotation.rotation_matrix().flatten()
+    #roverToCamera = driver.cahvor_rotation_matrix
+    #EcefToCamera = np.matmul(roverToCamera, EcefToRover)
+    #instrument_pointing['constant_rotation'] = EcefToCamera.flatten()
+    # Set this to identity for now
+    #print("--temporary 6")
+    #instrument_pointing['constant_rotation'] = np.identity(3).flatten()
+    print("++destination_frame is ", destination_frame, spice.frmnam(destination_frame))
+    print("+2sensor_frame is ", sensor_frame)
+    # below we have mast to camera
+    constant_rotation = frame_chain.compute_rotation(destination_frame, sensor_frame)
+    print("---2sensor frame is ", sensor_frame)
+    instrument_pointing['constant_rotation'] = constant_rotation.rotation_matrix().flatten()
     #print("new rotation is ", EcefToCamera)
     #print("Will compute rotation from destination_frame to sensor_frame")
     #print("old rotation (same as cahvor) is ", frame_chain.compute_rotation#(destination_frame, sensor_frame).rotation_matrix())
@@ -205,8 +220,8 @@ def to_isd(driver):
     # to be on different locations on the rover. Get the CAHVOR center, and 
     # convert it from that camera's coordinates to ECEF, then add it to the
     # rover position.
-    camCtrEcef = np.matmul(np.linalg.inv(EcefToRover), driver.cahvor_center)[0]
-    positions[0] += camCtrEcef
+    #camCtrEcef = np.matmul(np.linalg.inv(EcefToRover), driver.cahvor_center)[0]
+    #positions[0] += camCtrEcef
 
     # This is a fix for the fact that the height above datum can suddenly change
     # by about 60 meters. If the user sets HEIGHT_ABOVE_DATUM then we will shift

--- a/ale/transformation.py
+++ b/ale/transformation.py
@@ -97,7 +97,6 @@ class FrameChain(nx.DiGraph):
     """
     @classmethod
     def from_spice(cls, sensor_frame, target_frame, center_ephemeris_time, ephemeris_times=[], nadir=False, exact_ck_times=False):
-        print("--Computing frame chain, sensor frame is ", sensor_frame, "=", spice.frmnam(sensor_frame), " target frame is ", target_frame, "=", spice.frmnam(target_frame)) 
         frame_chain = cls()
         sensor_times = []
         # Default assume one time
@@ -268,7 +267,6 @@ class FrameChain(nx.DiGraph):
           Returns the source node id, destination node id, and edge dictionary
           which contains the rotation from source to destination.
         """
-        #("--now in last time dependent frame between ", source, " and ", destination)
         path = shortest_path(self, source, destination)
         # Reverse the path to search bottom up to find the last time dependent
         # frame between the source and destination
@@ -401,19 +399,15 @@ class FrameChain(nx.DiGraph):
         """
         for s, d in frames:
 
-            print("time dependent frame s =", s, '=', spice.frmnam(s), "d=", d, '=', spice.frmnam(d))
-        
             quats = np.zeros((len(times), 4))
             avs = []
             for j, time in enumerate(times):
                 try:
-                    #print("---1")
                     state_matrix = spice.sxform(spice.frmnam(s), spice.frmnam(d), time)
                     rotation_matrix, av = spice.xf2rav(state_matrix)
                     avs.append(av)
                 except:
                     rotation_matrix = spice.pxform(spice.frmnam(s), spice.frmnam(d), time)
-                    #print("except frame s =", s, '=', spice.frmnam(s), ", d=", d, '=', spice.frmnam(d), " rotation ", rotation_matrix.flatten())
                 quat_from_rotation = spice.m2q(rotation_matrix)
                 quats[j,:3] = quat_from_rotation[1:]
                 quats[j,3] = quat_from_rotation[0]

--- a/ale/transformation.py
+++ b/ale/transformation.py
@@ -97,7 +97,7 @@ class FrameChain(nx.DiGraph):
     """
     @classmethod
     def from_spice(cls, sensor_frame, target_frame, center_ephemeris_time, ephemeris_times=[], nadir=False, exact_ck_times=False):
-        #print("--Computing frame chain, sensor frame is ", sensor_frame, "=", spice.frmnam(sensor_frame), " target frame is ", target_frame, "=", spice.frmnam(target_frame)) 
+        print("--Computing frame chain, sensor frame is ", sensor_frame, "=", spice.frmnam(sensor_frame), " target frame is ", target_frame, "=", spice.frmnam(target_frame)) 
         frame_chain = cls()
         sensor_times = []
         # Default assume one time
@@ -132,7 +132,7 @@ class FrameChain(nx.DiGraph):
             #print("--constant frames are ", s, d)
             quats = np.zeros(4)
             rotation_matrix = spice.pxform(spice.frmnam(s), spice.frmnam(d), ephemeris_times[0])
-            #print("frames: s=", s, '=', spice.frmnam(s), ", d=", d, '=', spice.frmnam(d), " rotation: ", rotation_matrix.flatten())
+            print("constant frames: s=", s, '=', spice.frmnam(s), ", d=", d, '=', spice.frmnam(d))
             quat_from_rotation = spice.m2q(rotation_matrix)
             quats[:3] = quat_from_rotation[1:]
             quats[3] = quat_from_rotation[0]
@@ -400,13 +400,16 @@ class FrameChain(nx.DiGraph):
                 A list of times to compute the rotation at
         """
         for s, d in frames:
+
+            print("time dependent frame s =", s, '=', spice.frmnam(s), "d=", d, '=', spice.frmnam(d))
+        
             quats = np.zeros((len(times), 4))
             avs = []
             for j, time in enumerate(times):
                 try:
+                    #print("---1")
                     state_matrix = spice.sxform(spice.frmnam(s), spice.frmnam(d), time)
                     rotation_matrix, av = spice.xf2rav(state_matrix)
-                    #print("try frame s =", s, '=', sspice.frmnam(s), ", d=", d, '=', spice.frmnam(d), " rotation ", rotation_matrix.flatten())
                     avs.append(av)
                 except:
                     rotation_matrix = spice.pxform(spice.frmnam(s), spice.frmnam(d), time)


### PR DESCRIPTION
I've been working with @acpaquette looking at some issues with the MSL implementation in ALE. I think I found a handful of potential issues, and the results become plausible after they are fixed. This will need a review and some more testing. The summary of fixes is the following, corresponding to the changes in the files:
 
 - Flipped the sign of two rows of the rotation matrix. Before this fix, the image was projecting strangely, with the sky projecting close to the camera and the ground projecting in the distance. I believe this is needed because the [paper we follow](https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/2003JE002199) uses the convention that x and y change sign (see equation (8a) and (8b)) and I think CSM does not do that.
 - Added 0.5 to optical center, because CSM uses the convention that upper-left pixel is (0.5, 0.5). I know other ALE drivers do that too. This likely needs some more thinking.
 - Fixed the functions focal2pixel_lines() and focal2pixel_samples(). These were not swapping x and y after going from line/sample to distorted sensor pixels. The fixed approach is consistent with the Dawn driver and what I had to do for DigitalGlobe CSM logic. Before this fix, projecting onto the ground was resulting in the sky being sideways. 
 - Fixed the functions detector_center_sample() and detector_center_line(). These were actually correct in the Cahvor class, but were overridden in the MslMastcamPds3NaifSpiceDriver class by some generic spice function which is not aware of the Cahvor() implementation.
 - Fixed the functions detector_start_line() and detector_start_sample(). Now setting the start line and start sample to 0. These values are used in CSM's computeDistortedFocalPlaneCoordinates() function together with the detector center values to shift a pixel. Setting them to something non-zero is inconsistent with the CAHVOR implementation.

Here's the result of map-projecting onto the MOLA DEM the MSL images 1099ML0048660020500398C00 and 1099ML0048660010500397E01 with ASP's mapproject and updated CSM ISD cameras.

![image](https://user-images.githubusercontent.com/1325676/214754668-bb9ee652-a12c-4fc6-94bb-41baa38fe3b5.png)

Things are as expected. In each image, the hole in the middle is where the camera is. The camera looks towards the lower-left corner. The sky is in the distance and the view expands that way. Some rays from the ground hit the sensor from behind, hence the junky thing in the upper-right. 

When these two images are overlaid with georeference info, they agree quite well, which is a good sign.

I think these changes go the right way. What is needed is to get a stereo pair with good convergence angle and with prior knowledge of the site to do a fool-proof sanity check.

I must say this work wasn't something assigned or funded. Spending a couple of days on this seems about right. If the changes make sense, hopefully more testing can be done. Later in the spring I am funded to do some CSM work when I can revisit this if need be.

