### PR TITLE
Disable coverage upload failure

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -54,6 +54,6 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'


### PR DESCRIPTION
Prevents tests from failing if the code coverage fails to push