### PR TITLE
MSL Fixes/Landed Addition

### DIFF
--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -479,7 +479,10 @@ class Cahvor():
                                                       ephemeris_times=self.ephemeris_time,
                                                       nadir=False, exact_ck_times=False)
             cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat()
-            cahvor_rotation = ConstantRotation(cahvor_quats, self.final_inst_frame, self.sensor_frame_id)
+            #cahvor_rotation = ConstantRotation(cahvor_quats, self.final_inst_frame, self.#sensor_frame_id)
+            cahvor_rotation = ConstantRotation(cahvor_quats, self.target_frame_id,
+                                               self.sensor_frame_id)
+
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain
 

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -473,22 +473,14 @@ class Cahvor():
           A networkx frame chain object
         """
         if not hasattr(self, '_frame_chain'):
-            self._frame_chain = FrameChain.from_spice(sensor_frame=self.spacecraft_id * 1000,
+            self._frame_chain = FrameChain.from_spice(sensor_frame=self.final_inst_frame,
                                                       target_frame=self.target_frame_id,
                                                       center_ephemeris_time=self.center_ephemeris_time,
                                                       ephemeris_times=self.ephemeris_time,
                                                       nadir=False, exact_ck_times=False)
-
-            # Extra temporary rotation in the rover frame
-            C1 = np.array([[6.80577524e-01, -9.11460527e-03,  7.32619382e-01],
-                            [ 7.32652737e-01,  4.81672679e-04, -6.80602479e-01],
-                            [ 5.85055122e-03,  9.99958359e-01,  7.00565704e-03]])
-            transformed_cahv = np.matmul(self.cahvor_rotation_matrix, C1)
-            cahvor_quats = Rotation.from_matrix(transformed_cahv).as_quat()
-
-            cahvor_rotation = ConstantRotation(cahvor_quats, self.spacecraft_id * 1000,
-                                               self.sensor_frame_id)
-
+            cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix)
+            quats = cahvor_quats.as_quat()
+            cahvor_rotation = ConstantRotation(quats, self.final_inst_frame, self.sensor_frame_id)
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain
 

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -451,7 +451,7 @@ class Cahvor():
             v_s = self.compute_v_s()
             H_prime = (self.cahvor_camera_dict['H'] - h_c * self.cahvor_camera_dict['A'])/h_s
             V_prime = (self.cahvor_camera_dict['V'] - v_c * self.cahvor_camera_dict['A'])/v_s
-            self._cahvor_rotation_matrix = np.array([H_prime, -V_prime, -self.cahvor_camera_dict['A']])
+            self._cahvor_rotation_matrix = np.array([-H_prime, V_prime, -self.cahvor_camera_dict['A']])
         return self._cahvor_rotation_matrix
 
     @property
@@ -487,7 +487,9 @@ class Cahvor():
         : float
           The detector center line/boresight center line
         """
-        return self.compute_v_c()
+        # Add here 0.5 for consistency with the CSM convention that the
+        # upper-left image pixel is at (0.5, 0.5).
+        return self.compute_v_c() + 0.5
 
     @property
     def detector_center_sample(self):
@@ -500,7 +502,9 @@ class Cahvor():
         : float
           The detector center sample/boresight center sample
         """
-        return self.compute_h_c()
+        # Add here 0.5 for consistency with the CSM convention that the
+        # upper-left image pixel is at (0.5, 0.5).
+        return self.compute_h_c() + 0.5
 
     @property
     def pixel_size(self):

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -386,6 +386,13 @@ class Cahvor():
         """
         raise NotImplementedError
 
+    @property
+    def final_inst_frame(self):
+      """
+      Defines the final frame before cahvor frame in the frame chain
+      """
+      raise NotImplementedError
+
     def compute_h_c(self):
         """
         Computes the h_c element of a cahvor model for the conversion

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -478,9 +478,8 @@ class Cahvor():
                                                       center_ephemeris_time=self.center_ephemeris_time,
                                                       ephemeris_times=self.ephemeris_time,
                                                       nadir=False, exact_ck_times=False)
-            cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix)
-            quats = cahvor_quats.as_quat()
-            cahvor_rotation = ConstantRotation(quats, self.final_inst_frame, self.sensor_frame_id)
+            cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat()
+            cahvor_rotation = ConstantRotation(cahvor_quats, self.final_inst_frame, self.sensor_frame_id)
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain
 

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -451,7 +451,7 @@ class Cahvor():
             v_s = self.compute_v_s()
             H_prime = (self.cahvor_camera_dict['H'] - h_c * self.cahvor_camera_dict['A'])/h_s
             V_prime = (self.cahvor_camera_dict['V'] - v_c * self.cahvor_camera_dict['A'])/v_s
-            self._cahvor_rotation_matrix = np.array([-H_prime, V_prime, -self.cahvor_camera_dict['A']])
+            self._cahvor_rotation_matrix = np.array([H_prime, -V_prime, self.cahvor_camera_dict['A']])
         return self._cahvor_rotation_matrix
 
     @property

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -96,7 +96,7 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector lines
         """
-        return [0, 1/self.pixel_size, 0]
+        return [0, 0, 1/self.pixel_size]
     
     @property
     def focal2pixel_samples(self):
@@ -108,23 +108,23 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector samples
         """
-        return [0, 0, 1/self.pixel_size]
+        return [0, 1/self.pixel_size, 0]
 
-    @property
-    def detector_center_line(self):
-        return self.label["INSTRUMENT_STATE_PARMS"]["DETECTOR_LINES"]/2
-
-    @property
-    def detector_center_sample(self):
-        return self.label["INSTRUMENT_STATE_PARMS"]["MSL:DETECTOR_SAMPLES"]/2
+    # The detector_center_line() and detector_center_sample()
+    # functions from Cahvor() will be invoked. There is no need to
+    # reimplement them here.
 
     @property
     def detector_start_line(self):
-        return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE"]
+        # Do not return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE"]
+        # The value 0 is consistent with the Cahvor camera model.
+        return 0
 
     @property
     def detector_start_sample(self):
-        return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE_SAMPLE"]
+        # Do not return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE_SAMPLE"])
+        # The value 0 is consistent with the Cahvor camera model.
+        return 0
 
     @property
     def sensor_model_version(self):

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -122,22 +122,6 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         """
         return [0, -1/self.pixel_size, 0]
 
-    # The detector_center_line() and detector_center_sample()
-    # functions from Cahvor() will be invoked. There is no need to
-    # reimplement them here.
-
-    @property
-    def detector_start_line(self):
-        # Do not return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE"]
-        # The value 0 is consistent with the Cahvor camera model.
-        return 0
-
-    @property
-    def detector_start_sample(self):
-        # Do not return self.label["IMAGE_REQUEST_PARMS"]["FIRST_LINE_SAMPLE"])
-        # The value 0 is consistent with the Cahvor camera model.
-        return 0
-
     @property
     def sensor_model_version(self):
         """

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -120,7 +120,7 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector samples
         """
-        return [0, 1/self.pixel_size, 0]
+        return [0, -1/self.pixel_size, 0]
 
     # The detector_center_line() and detector_center_sample()
     # functions from Cahvor() will be invoked. There is no need to

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -70,6 +70,18 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         return self._cahvor_camera_params
 
     @property
+    def final_inst_frame(self):
+        """
+        Defines MSLs last naif frame before the cahvor model frame
+
+        Returns
+        -------
+        : int
+          Naif frame code for MSL_RSM_HEAD
+        """
+        return spice.bods2c("MSL_RSM_HEAD")
+
+    @property
     def sensor_frame_id(self):
         """
         Returns the Naif ID code for the site reference frame

--- a/ale/formatters/formatter.py
+++ b/ale/formatters/formatter.py
@@ -118,7 +118,7 @@ def to_isd(driver):
     sensor_frame = driver.sensor_frame_id
 
     instrument_pointing = {}
-    source_frame, destination_frame, time_dependent_sensor_frame = frame_chain.last_time_dependent_frame_between(1, sensor_frame)
+    source_frame, destination_frame, _ = frame_chain.last_time_dependent_frame_between(1, sensor_frame)
 
     # Reverse the frame order because ISIS orders frames as
     # (destination, intermediate, ..., intermediate, source)

--- a/ale/isd_generate.py
+++ b/ale/isd_generate.py
@@ -68,6 +68,12 @@ def main():
         help="Only use drivers that generate fresh spice data"
     )
     parser.add_argument(
+        "-l", "--local",
+        action="store_false",
+        help="Generate local spice data, or image that is unaware of itself relative to "
+             "target body. This is largely used for landed/rover data."
+    )
+    parser.add_argument(
         '--version',
         action='version',
         version=f"ale version {ale.__version__}",
@@ -107,7 +113,11 @@ def main():
         ) as executor:
             futures = {
                 executor.submit(
-                    file_to_isd, f, **{"kernels": k, "log_level": log_level, "only_isis_spice": args.only_isis_spice, "only_naif_spice": args.only_naif_spice}
+                    file_to_isd, f, **{"kernels": k, 
+                                       "log_level": log_level, 
+                                       "only_isis_spice": args.only_isis_spice, 
+                                       "only_naif_spice": args.only_naif_spice,
+                                       "landed": args.landed}
                 ): f for f in args.input
             }
             for f in concurrent.futures.as_completed(futures):
@@ -127,7 +137,8 @@ def file_to_isd(
     kernels: list = None,
     log_level=logging.WARNING,
     only_isis_spice=False,
-    only_naif_spice=False
+    only_naif_spice=False,
+    landed=False
 ):
     """
     Returns nothing, but acts as a thin wrapper to take the *file* and generate
@@ -151,7 +162,7 @@ def file_to_isd(
     logger.setLevel(log_level)
 
     logger.info(f"Reading: {file}")
-    props = {}
+    props = {"landed": landed}
     if kernels is not None:
         kernels = [str(PurePath(p)) for p in kernels]
         props["kernels"] = kernels

--- a/ale/isd_generate.py
+++ b/ale/isd_generate.py
@@ -69,7 +69,7 @@ def main():
     )
     parser.add_argument(
         "-l", "--local",
-        action="store_false",
+        action="store_true",
         help="Generate local spice data, or image that is unaware of itself relative to "
              "target body. This is largely used for landed/rover data."
     )
@@ -103,7 +103,7 @@ def main():
 
     if len(args.input) == 1:
         try:
-            file_to_isd(args.input[0], args.out, kernels=k, log_level=log_level, only_isis_spice=args.only_isis_spice, only_naif_spice=args.only_naif_spice)
+            file_to_isd(args.input[0], args.out, kernels=k, log_level=log_level, only_isis_spice=args.only_isis_spice, only_naif_spice=args.only_naif_spice, local=args.local)
         except Exception as err:
             # Seriously, this just throws a generic Exception?
             sys.exit(f"File {args.input[0]}: {err}")
@@ -117,7 +117,7 @@ def main():
                                        "log_level": log_level, 
                                        "only_isis_spice": args.only_isis_spice, 
                                        "only_naif_spice": args.only_naif_spice,
-                                       "landed": args.landed}
+                                       "local": args.local}
                 ): f for f in args.input
             }
             for f in concurrent.futures.as_completed(futures):
@@ -138,7 +138,7 @@ def file_to_isd(
     log_level=logging.WARNING,
     only_isis_spice=False,
     only_naif_spice=False,
-    landed=False
+    local=False
 ):
     """
     Returns nothing, but acts as a thin wrapper to take the *file* and generate
@@ -162,7 +162,11 @@ def file_to_isd(
     logger.setLevel(log_level)
 
     logger.info(f"Reading: {file}")
-    props = {"landed": landed}
+    props = {}
+
+    if local:
+        props['landed'] = local
+
     if kernels is not None:
         kernels = [str(PurePath(p)) for p in kernels]
         props["kernels"] = kernels

--- a/tests/pytests/test_cahvor_mixin.py
+++ b/tests/pytests/test_cahvor_mixin.py
@@ -27,6 +27,7 @@ class test_cahvor_sensor(unittest.TestCase):
         self.driver.target_frame_id = 10014
         self.driver.center_ephemeris_time = 0
         self.driver.ephemeris_time = [0]
+        self.driver._props = {}
 
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
     def test_compute_functions(self, cahvor_camera_dict):
@@ -39,26 +40,28 @@ class test_cahvor_sensor(unittest.TestCase):
     def test_cahvor_model_elements(self, cahvor_camera_dict):
         cahvor_matrix = self.driver.cahvor_rotation_matrix
         np.testing.assert_allclose(cahvor_matrix, [[-0.82067034, -0.57129702, 0.01095033],
-                                                   [-0.43920248, 0.6184257, -0.65165238],
-                                                   [ 0.3655151, -0.5396012, -0.7584387 ]])
+                                                   [0.43920248, -0.6184257, 0.65165238],
+                                                   [ -0.3655151, 0.5396012, 0.7584387 ]])
 
     @patch('ale.transformation.FrameChain.from_spice', return_value=ale.transformation.FrameChain())
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
-    def test_cahvor_frame_chain(self, cahvor_camera_dict, from_spice):
+    @patch("ale.base.type_sensor.Cahvor.final_inst_frame", new_callable=PropertyMock, return_value=-76000)
+    def test_cahvor_frame_chain(self, final_inst_frame, cahvor_camera_dict, from_spice):
       frame_chain = self.driver.frame_chain
       assert len(frame_chain.nodes()) == 2
       assert -76000 in frame_chain.nodes()
       assert -76562 in frame_chain.nodes()
       from_spice.assert_called_with(center_ephemeris_time=0, ephemeris_times=[0], sensor_frame=-76000, target_frame=10014, nadir=False, exact_ck_times=False)
-      np.testing.assert_allclose(frame_chain[-76562][-76000]['rotation'].quat, [-0.28255205, 0.8940826, -0.33309383, 0.09914206])
+      print(frame_chain[-76562][-76000]['rotation'].quat[3])
+      np.testing.assert_allclose(frame_chain[-76562][-76000]['rotation'].quat, [-0.09914206260782343, 0.3330938313054434, 0.8940825953723198, -0.28255205470925904])
 
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
     def test_cahvor_detector_center_line(self, cahvor_camera_dict):
-        np.testing.assert_almost_equal(self.driver.detector_center_line, 590.1933422831007)
+        np.testing.assert_almost_equal(self.driver.detector_center_line, 590.6933422831007)
     
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
     def test_cahvor_detector_center_sample(self, cahvor_camera_dict):
-        np.testing.assert_almost_equal(self.driver.detector_center_sample, 673.4306859859296)
+        np.testing.assert_almost_equal(self.driver.detector_center_sample, 673.9306859859296)
 
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
     def test_cahvor_pixel_size(self, cahvor_camera_dict):

--- a/tests/pytests/test_msl_drivers.py
+++ b/tests/pytests/test_msl_drivers.py
@@ -36,13 +36,13 @@ class test_mastcam_pds_naif(unittest.TestCase):
     def test_focal2pixel_lines(self):
         with patch('ale.drivers.msl_drivers.spice.bods2c', new_callable=PropertyMock, return_value=-76220) as bods2c, \
              patch('ale.drivers.msl_drivers.spice.gdpool', new_callable=PropertyMock, return_value=[100]) as gdpool:
-            np.testing.assert_allclose(self.driver.focal2pixel_lines, [0, 137.96844341513602, 0])
+            np.testing.assert_allclose(self.driver.focal2pixel_lines, [0, 0, 137.96844341513602])
             bods2c.assert_called_with('MSL_MASTCAM_RIGHT')
             gdpool.assert_called_with('INS-76220_FOCAL_LENGTH', 0, 1)
 
     def test_focal2pixel_samples(self):
         with patch('ale.drivers.msl_drivers.spice.bods2c', new_callable=PropertyMock, return_value=-76220) as bods2c, \
              patch('ale.drivers.msl_drivers.spice.gdpool', new_callable=PropertyMock, return_value=[100]) as gdpool:
-            np.testing.assert_allclose(self.driver.focal2pixel_samples, [0, 0, 137.96844341513602])
+            np.testing.assert_allclose(self.driver.focal2pixel_samples, [0, -137.96844341513602, 0])
             bods2c.assert_called_with('MSL_MASTCAM_RIGHT')
             gdpool.assert_called_with('INS-76220_FOCAL_LENGTH', 0, 1)

--- a/tests/pytests/test_msl_drivers.py
+++ b/tests/pytests/test_msl_drivers.py
@@ -20,6 +20,11 @@ class test_mastcam_pds_naif(unittest.TestCase):
     def test_exposure_duration(self):
         np.testing.assert_almost_equal(self.driver.exposure_duration, 0.0102)
 
+    def test_final_inst_frame(self):
+        with patch('ale.drivers.msl_drivers.spice.bods2c', new_callable=PropertyMock, return_value=-76562) as bods2c:
+            assert self.driver.final_inst_frame == -76562
+            bods2c.assert_called_with("MSL_RSM_HEAD")
+
     def test_cahvor_camera_dict(self):
         cahvor_camera_dict = self.driver.cahvor_camera_dict
         assert len(cahvor_camera_dict) == 4


### PR DESCRIPTION
Allows MSL ISDs to be generated with zero'd positions and velocities and adjusted pointing information.

This change allows the rover images to be locally projected relative to the rover. 

Works in ISIS using skymap.