### PR TITLE
Add radtan distortion

### DIFF
--- a/include/ale/Distortion.h
+++ b/include/ale/Distortion.h
@@ -9,7 +9,8 @@ namespace ale {
     DAWNFC,
     LROLROCNAC,
     CAHVOR,
-    LUNARORBITER
+    LUNARORBITER,
+    RADTAN
   };
 }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -342,9 +342,9 @@ double getSemiMinorRadius(json isd) {
 // type. Defaults to transverse
 DistortionType getDistortionModel(json isd) {
   try {
-    json distoriton_subset = isd.at("optical_distortion");
+    json distortion_subset = isd.at("optical_distortion");
 
-    json::iterator it = distoriton_subset.begin();
+    json::iterator it = distortion_subset.begin();
 
     std::string distortion = (std::string)it.key();
 
@@ -362,6 +362,8 @@ DistortionType getDistortionModel(json isd) {
       return DistortionType::CAHVOR;
     } else if (distortion.compare("lunarorbiter") == 0) {
       return DistortionType::LUNARORBITER;
+    } else if (distortion.compare("radtan") == 0) {
+      return DistortionType::RADTAN;
     }
   } catch (...) {
     throw std::runtime_error("Could not parse the distortion model.");
@@ -526,6 +528,20 @@ std::vector<double> getDistortionCoeffs(json isd) {
         throw std::runtime_error(
           "Could not parse the Lunar Orbiter distortion model coefficients.");
         coefficients = std::vector<double>(4, 0.0);
+      }
+    } break;
+    case DistortionType::RADTAN: {
+      try {
+        coefficients = isd.at("optical_distortion")
+                          .at("radtan")
+                          .at("coefficients")
+                          .get<std::vector<double>>();
+
+        return coefficients;
+      } catch (...) {
+        throw std::runtime_error(
+            "Could not parse the radtan distortion model coefficients.");
+        coefficients = std::vector<double>(5, 0.0);
       }
     } break;
   }


### PR DESCRIPTION
Add support for the radial + tangential distortion model. This has 5 distortion coefficients, stored in order k1, k2, p1, p2, k3. The k1, k2, k3 coefficients are for radial distortion, and p1 and p2 for tangential distortion. This was validated with the OpenCV implementation using the function cv::projectPoints(). More background in https://github.com/DOI-USGS/usgscsm/issues/465. 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

