### PR TITLE
Replace affine6p transformation with numpy solution

### DIFF
--- a/tests/pytests/test_lo_drivers.py
+++ b/tests/pytests/test_lo_drivers.py
@@ -98,7 +98,6 @@ class test_high_isis3_naif(unittest.TestCase):
             namfrm.assert_called_with("LO3_HIGH_RESOLUTION_CAMERA")
 
     def test_naif_keywords(self):
-
         with patch('ale.drivers.lo_drivers.LoHighCameraIsisLabelNaifSpiceDriver.ikid', new_callable=PropertyMock) as ikid, \
             patch('ale.base.data_naif.spice.bodvrd', return_value=[1737.4, 1737.4, 1737.4]) as bodvrd:
 
@@ -114,6 +113,22 @@ class test_high_isis3_naif(unittest.TestCase):
                 "INS-533001_ITRANSL" : [4541.692430539061, -0.05845617762411283, 143.95514969883214]
             }
             
-            assert self.driver.naif_keywords == naif_keywords
+            assert self.driver.naif_keywords["BODY_CODE"] == naif_keywords["BODY_CODE"]
+            assert self.driver.naif_keywords["BODY301_RADII"] == naif_keywords["BODY301_RADII"]
+            assert self.driver.naif_keywords["BODY_FRAME_CODE"] == naif_keywords["BODY_FRAME_CODE"]
+
+            np.testing.assert_almost_equal(np.asarray(self.driver.naif_keywords["INS-533001_TRANSX"]), 
+                                           np.asarray(naif_keywords["INS-533001_TRANSX"]), 
+                                           decimal=10)
+            np.testing.assert_almost_equal(np.asarray(self.driver.naif_keywords["INS-533001_TRANSY"]), 
+                                           np.asarray(naif_keywords["INS-533001_TRANSY"]), 
+                                           decimal=10)
+            np.testing.assert_almost_equal(np.asarray(self.driver.naif_keywords["INS-533001_ITRANSS"]), 
+                                           np.asarray(naif_keywords["INS-533001_ITRANSS"]), 
+                                           decimal=10)
+            np.testing.assert_almost_equal(np.asarray(self.driver.naif_keywords["INS-533001_ITRANSL"]), 
+                                           np.asarray(naif_keywords["INS-533001_ITRANSL"]), 
+                                           decimal=10)
+
             bodvrd.assert_called_with('Moon', 'RADII', 3)
   


### PR DESCRIPTION
Addresses https://github.com/DOI-USGS/ale/issues/573

The `numpy` solution is from https://stackoverflow.com/a/20555267.

Both the `numpy` solution and `affine6p` solution uses the least squares method (repo link for `affine6p` [here](https://gitlab.com/yoshimoto/affine6p-py)).

This file [affine_differences.txt](https://github.com/DOI-USGS/ale/files/13397291/affine_differences.txt) shows the pytest difference output between the `affine6p` and `numpy` transformation estimations, respectively. The `numpy` output is fairly accurate to around the 10th decimal in comparison to the existing `affine6p` output in the `test_naif_keywords()` test. 

Updated the `test_lo_drivers.py` to assert the `TRANSX`, `TRANSY`, `ITRANSS`, and `ITRANSL` values are almost equal to the `affine6p` output.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

