### PR TITLE
Bufixes for MSL sensor intrinsics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ release.
 ### Fixed
 - Fixed LRO MiniRF drivers naif keywords focal to pixel and pixel to focal translations to be correct. [#569](https://github.com/DOI-USGS/ale/pull/569)
 - Bugfix for position and orientation for MSL cameras (driver MslMastcamPds3NaifSpiceDriver). Validated that Nav and Mast LBL files (for both left and right sensor) produce correctly positioned and oriented CSM cameras, that are self-consistent and consistent with a prior DEM for the site. [#580](https://github.com/DOI-USGS/ale/pull/580) 
+- Bug fix for ray direction for MSL. [#589](https://github.com/DOI-USGS/ale/pull/589)
 
 ### Changed
 - Removed the affine6p library and replaced affine6p's affine transformation with a numpy solution [#579](https://github.com/DOI-USGS/ale/pull/579) 

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -612,4 +612,4 @@ class Cahvor():
         : float
           Pixel size of a cahvor model instrument
         """
-        return -self.focal_length/self.compute_h_s()
+        return self.focal_length/self.compute_h_s()

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -126,7 +126,7 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector lines
         """
-        return [0, 0, -1/self.pixel_size]
+        return [0, 0, 1/self.pixel_size]
     
     @property
     def focal2pixel_samples(self):
@@ -138,7 +138,7 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         : list<double>
           focal plane to detector samples
         """
-        return [0, -1/self.pixel_size, 0]
+        return [0, 1/self.pixel_size, 0]
 
     @property
     def sensor_model_version(self):
@@ -181,10 +181,10 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
         if self.is_navcam:
             # Focal length in pixel as computed for a cahvor model.
             # See is_navcam() for an explanation.
-            return -(self.compute_h_s() + self.compute_v_s())/2.0
+            return (self.compute_h_s() + self.compute_v_s())/2.0
         
-        # For mast cam    
-        return -super().focal_length 
+        # For mast cam
+        return super().focal_length 
 
     @property
     def pixel_size(self):
@@ -200,5 +200,5 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
             # See is_navcam() for an explanation.
             return 1.0
             
-        # For mast cam    
+        # For mast cam
         return super().pixel_size 

--- a/tests/pytests/data/isds/msl_isd.json
+++ b/tests/pytests/data/isds/msl_isd.json
@@ -226,7 +226,7 @@
   "detector_sample_summing": 1,
   "detector_line_summing": 1,
   "focal_length_model": {
-    "focal_length": -34.0
+    "focal_length": 34.0
   },
   "detector_center": {
     "line": 576.4026068104001,
@@ -235,11 +235,11 @@
   "focal2pixel_lines": [
     0,
     0,
-    -136.49886775101947
+    136.49886775101947
   ],
   "focal2pixel_samples": [
     0,
-    -136.49886775101947,
+    136.49886775101947,
     0
   ],
   "optical_distortion": {

--- a/tests/pytests/data/isds/msl_nadir_isd.json
+++ b/tests/pytests/data/isds/msl_nadir_isd.json
@@ -217,7 +217,7 @@
   "detector_sample_summing": 1,
   "detector_line_summing": 1,
   "focal_length_model": {
-    "focal_length": -34.0
+    "focal_length": 34.0
   },
   "detector_center": {
     "line": 576.4026068104001,
@@ -226,11 +226,11 @@
   "focal2pixel_lines": [
     0,
     0,
-    -136.49886775101947
+    136.49886775101947
   ],
   "focal2pixel_samples": [
     0,
-    -136.49886775101947,
+    136.49886775101947,
     0
   ],
   "optical_distortion": {

--- a/tests/pytests/test_cahvor_mixin.py
+++ b/tests/pytests/test_cahvor_mixin.py
@@ -65,4 +65,4 @@ class test_cahvor_sensor(unittest.TestCase):
 
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
     def test_cahvor_pixel_size(self, cahvor_camera_dict):
-        assert self.driver.pixel_size == -0.007248034226138798
+        assert self.driver.pixel_size == 0.007248034226138798

--- a/tests/pytests/test_msl_drivers.py
+++ b/tests/pytests/test_msl_drivers.py
@@ -73,13 +73,13 @@ class test_mastcam_pds_naif(unittest.TestCase):
     def test_focal2pixel_lines(self):
         with patch('ale.drivers.msl_drivers.spice.bods2c', new_callable=PropertyMock, return_value=-76220) as bods2c, \
              patch('ale.drivers.msl_drivers.spice.gdpool', new_callable=PropertyMock, return_value=[100]) as gdpool:
-            np.testing.assert_allclose(self.driver.focal2pixel_lines, [0, 0, -137.96844341513602])
+            np.testing.assert_allclose(self.driver.focal2pixel_lines, [0, 0, 137.96844341513602])
             bods2c.assert_called_with('MSL_MASTCAM_RIGHT')
             gdpool.assert_called_with('INS-76220_FOCAL_LENGTH', 0, 1)
 
     def test_focal2pixel_samples(self):
         with patch('ale.drivers.msl_drivers.spice.bods2c', new_callable=PropertyMock, return_value=-76220) as bods2c, \
              patch('ale.drivers.msl_drivers.spice.gdpool', new_callable=PropertyMock, return_value=[100]) as gdpool:
-            np.testing.assert_allclose(self.driver.focal2pixel_samples, [0, -137.96844341513602, 0])
+            np.testing.assert_allclose(self.driver.focal2pixel_samples, [0, 137.96844341513602, 0])
             bods2c.assert_called_with('MSL_MASTCAM_RIGHT')
             gdpool.assert_called_with('INS-76220_FOCAL_LENGTH', 0, 1)


### PR DESCRIPTION
This is a fix for a bug I made with MSL cameras.

This bug explains part of the problem of why ISIS is having a hard time with MSL data.

A corresponding bug was fixed in ASP. The build 2024-01-12 has that. An earlier ASP build will now give wrong result.

The root cause of the problem was that for MSL the zero datum is not beneath the rover, but above it, so some heuristics was failing. 

Things were working with mapproject because two bugs were canceling each other out (since I developed both). No such luck with ISIS.

This was very carefully tested with many SOL00603 MAST and NAV images. The most relevant pair is:

SOL00603/NLB_451026746EDR_F0311094NCAM00271M1
MAST_0603/0603ML0025450040301380C00_DRCL

These can be used with the MSL DEM I shared with @acpaquette.

I am not sure a new changelog entry is needed, since the existing MSL work is already listed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

