### PR TITLE
Msl Landed Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed landed sensors to correctly project locally [#590](https://github.com/DOI-USGS/ale/pull/590)
+
 ## [0.10.0] - 2024-01-08 
 
 ### Added

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -500,10 +500,7 @@ class Cahvor():
             v_s = self.compute_v_s()
             H_prime = (self.cahvor_camera_dict['H'] - h_c * self.cahvor_camera_dict['A'])/h_s
             V_prime = (self.cahvor_camera_dict['V'] - v_c * self.cahvor_camera_dict['A'])/v_s
-            if self._props.get("landed", False):
-              self._cahvor_rotation_matrix = np.array([-H_prime, -V_prime, self.cahvor_camera_dict['A']])
-            else:
-              self._cahvor_rotation_matrix = np.array([H_prime, V_prime, self.cahvor_camera_dict['A']])
+            self._cahvor_rotation_matrix = np.array([H_prime, V_prime, self.cahvor_camera_dict['A']])
         return self._cahvor_rotation_matrix
 
     @property

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -183,8 +183,11 @@ class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, Cahvor
             # See is_navcam() for an explanation.
             return (self.compute_h_s() + self.compute_v_s())/2.0
         
+        if self._props.get("landed", False):
+            return -super().focal_length
+
         # For mast cam
-        return super().focal_length 
+        return super().focal_length
 
     @property
     def pixel_size(self):


### PR DESCRIPTION
Updated what the "landed" props argument does for MSL. To get accurate sky projections in ISIS we just need to invert the focal length and set the spacecraft (rover) position to the center of the target body.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

