### PR TITLE
Hayabusa amica Ephemeris Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ release.
 ### Fixed
 
 - Fixed landed sensors to correctly project locally [#590](https://github.com/DOI-USGS/ale/pull/590)
+- Fixed Hayabusa amica center time computation to match ISIS [#592](https://github.com/DOI-USGS/ale/pull/592)
 
 ## [0.10.0] - 2024-01-08 
 

--- a/ale/drivers/hayabusa_drivers.py
+++ b/ale/drivers/hayabusa_drivers.py
@@ -19,6 +19,18 @@ class HayabusaAmicaIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, Radial
         """
         lookup_table = {'AMICA': 'HAYABUSA_AMICA'}
         return lookup_table[super().instrument_id]
+    
+    @property
+    def center_ephemeris_time(self):
+        """
+        Returns the average of the start and stop ephemeris times.
+
+        Returns
+        -------
+        : double
+          Center ephemeris time for an image
+        """
+        return self.ephemeris_start_time + self.exposure_duration / 2
 
     @property
     def sensor_model_version(self):

--- a/ale/drivers/hayabusa_drivers.py
+++ b/ale/drivers/hayabusa_drivers.py
@@ -23,7 +23,7 @@ class HayabusaAmicaIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, Radial
     @property
     def center_ephemeris_time(self):
         """
-        Returns the average of the start and stop ephemeris times.
+        Returns the start ephemeris time plus half the exposure duration.
 
         Returns
         -------

--- a/tests/pytests/test_hayabusa_drivers.py
+++ b/tests/pytests/test_hayabusa_drivers.py
@@ -37,6 +37,11 @@ class test_amica_isis_naif(unittest.TestCase):
 
     def test_instrument_id(self):
         assert self.driver.instrument_id == "HAYABUSA_AMICA"
+
+    def test_center_ephemeris_time(self):
+        with patch('ale.drivers.hayabusa_drivers.spice.scs2e', return_value=12345) as scs2e:
+            assert self.driver.center_ephemeris_time == 12345 + 0.0109
+            scs2e.assert_called_with(-130, '2457499394')
     
     def test_sensor_model_version(self):
         assert self.driver.sensor_model_version == 1


### PR DESCRIPTION
Fixes a small time difference between ISIS and ALE when computing the center ephemeris time

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

