### PR TITLE
Enable haybusa2 ONC IsisLabelNaifSpice driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ release.
 -->
 
 ## [Unreleased]
+### Changed
+- Enabled Hayabusa2 drivers [#596](https://github.com/DOI-USGS/ale/pull/596)
+
 ### Added
 - Apollo Metric drivers, tests, and data [#533](https://github.com/DOI-USGS/ale/pull/533)
 

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -24,7 +24,6 @@ from abc import ABC
 
 # Explicit list of disabled drivers
 __disabled_drivers__ = ["ody_drivers",
-                        "hayabusa2_drivers",
                         "juno_drivers",
                         "tgo_drivers",
                         "msi_drivers"]


### PR DESCRIPTION
Enables the hayabusa2 ONC ISISLabelNaifSpice driver for use in ISIS to get spice data. See the attached image for verification of ephemeris data:
<img width="722" alt="Screenshot 2024-03-04 at 12 47 16 PM" src="https://github.com/DOI-USGS/ale/assets/17728237/aa49ac73-dae8-437d-966b-cc6cfd151fee">

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

