### PR TITLE
Update isd_generate.py to support optional function to ensure that instrument pointing quaternions do not change sign

### DIFF
--- a/ale/isd_generate.py
+++ b/ale/isd_generate.py
@@ -280,7 +280,6 @@ def fix_quaternion_signs(usgscsm_str):
     usgscsm_json = json.loads(usgscsm_str)
     quats = usgscsm_json["instrument_pointing"]["quaternions"]
     
-    logger.info(f"fixing any quaternions that have a sign change")
     # First find the largest magnitude quaternion coefficient and its coordinate
     num_quats = len(quats)
     max_q = 0.0
@@ -292,13 +291,16 @@ def fix_quaternion_signs(usgscsm_str):
                 max_j = j
     
     # Ensure the signs are consistent
+    qcnt = 0
     for i in range(num_quats):
         if quats[i][max_j] * max_q < 0:
+            qcnt = qcnt + 1
             for j in range(4):
                 quats[i][j] *= -1.0
     
     usgscsm_json["instrument_pointing"]["quaternions"] = quats
     usgscsm_str = json.dumps(usgscsm_json, indent=2)
+    logger.info(f"updated {} of {} quaternions that have a sign change".format(qcnt, range(quats)))
     return usgscsm_str
 
 

--- a/ale/isd_generate.py
+++ b/ale/isd_generate.py
@@ -300,7 +300,7 @@ def fix_quaternion_signs(usgscsm_str):
     
     usgscsm_json["instrument_pointing"]["quaternions"] = quats
     usgscsm_str = json.dumps(usgscsm_json, indent=2)
-    logger.info(f"updated {} of {} quaternions that have a sign change".format(qcnt, range(quats)))
+    logger.info("updated {} of {} quaternions that have a sign change".format(qcnt, range(quats)))
     return usgscsm_str
 
 

--- a/ale/isd_generate.py
+++ b/ale/isd_generate.py
@@ -300,7 +300,7 @@ def fix_quaternion_signs(usgscsm_str):
     
     usgscsm_json["instrument_pointing"]["quaternions"] = quats
     usgscsm_str = json.dumps(usgscsm_json, indent=2)
-    logger.info("updated {} of {} quaternions that have a sign change".format(qcnt, range(quats)))
+    logger.info("updated {} of {} quaternions that have a sign change".format(qcnt, num_quats))
     return usgscsm_str
 
 


### PR DESCRIPTION
Implement an optional function to ensure that instrument pointing quaternions do not change sign.

This is really more to continue the discussion under issue #603 . I understand that NAIF is supposed to return the quaternions with flipped signs, but this seems to be breaking our applications. ASP has been [updated](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/222cb5fd64a6ea2fb723da964a131925e6ce7501/src/asp/Camera/CsmUtils.cc#L34) to account for this issue. This example function for isd_generate.py, following ASP's logic, could also be used to "clean" the ISD for other applications like SOCET GXP.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

