### PR TITLE
Allow ale formatter to proceed with no velocities specified for instrument/sun position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ release.
 - Apollo Metric drivers, tests, and data [#533](https://github.com/DOI-USGS/ale/pull/533)
 - Rosetta Virtis drivers, tests, and data [#520](https://github.com/DOI-USGS/ale/pull/520)
 - Added compress and decompress ISD functions and added --compress flag to isd_generate[#604](https://github.com/DOI-USGS/ale/issues/604)
+- Added the ability to generate ISDs with no velocities specified for instrument/sun position [#614](https://github.com/DOI-USGS/ale/issues/614)
 
 ### Changed
 - Changed how push frame sensor drivers compute the `ephemeris_time` property [#595](https://github.com/DOI-USGS/ale/pull/595)

--- a/ale/formatters/formatter.py
+++ b/ale/formatters/formatter.py
@@ -176,14 +176,12 @@ def to_isd(driver):
     instrument_position['spk_table_original_size'] = len(times)
     instrument_position['ephemeris_times'] = times
     # Rotate positions and velocities into J2000 then scale into kilometers
-    # If velocities are provided, then rotate, otherwise create array of 0s to match shape of position
+    # If velocities are provided, then rotate and add to ISD
     if velocities is not None:
         velocities = j2000_rotation.rotate_velocity_at(positions, velocities, times)/1000
-    else:
-        velocities = np.zeros(positions.shape)
+        instrument_position['velocities'] = velocities
     positions = j2000_rotation.apply_at(positions, times)/1000
     instrument_position['positions'] = positions
-    instrument_position['velocities'] = velocities
     instrument_position["reference_frame"] = j2000_rotation.dest
 
     meta_data['instrument_position'] = instrument_position
@@ -195,14 +193,12 @@ def to_isd(driver):
     sun_position['spk_table_original_size'] = len(times)
     sun_position['ephemeris_times'] = times
     # Rotate positions and velocities into J2000 then scale into kilometers
-    # If velocities are provided, then rotate, otherwise create array of 0s to match shape of position
+    # If velocities are provided, then rotate and add to ISD
     if velocities is not None:
         velocities = j2000_rotation.rotate_velocity_at(positions, velocities, times)/1000
-    else:
-        velocities = np.zeros(positions.shape)
-    positions = j2000_rotation.apply_at(positions, times)/1000
+        positions = j2000_rotation.apply_at(positions, times)/1000
+        sun_position['velocities'] = velocities
     sun_position['positions'] = positions
-    sun_position['velocities'] = velocities
     sun_position["reference_frame"] = j2000_rotation.dest
 
     meta_data['sun_position'] = sun_position

--- a/ale/formatters/formatter.py
+++ b/ale/formatters/formatter.py
@@ -196,8 +196,9 @@ def to_isd(driver):
     # If velocities are provided, then rotate and add to ISD
     if velocities is not None:
         velocities = j2000_rotation.rotate_velocity_at(positions, velocities, times)/1000
-        positions = j2000_rotation.apply_at(positions, times)/1000
         sun_position['velocities'] = velocities
+    
+    positions = j2000_rotation.apply_at(positions, times)/1000
     sun_position['positions'] = positions
     sun_position["reference_frame"] = j2000_rotation.dest
 

--- a/ale/formatters/formatter.py
+++ b/ale/formatters/formatter.py
@@ -176,7 +176,11 @@ def to_isd(driver):
     instrument_position['spk_table_original_size'] = len(times)
     instrument_position['ephemeris_times'] = times
     # Rotate positions and velocities into J2000 then scale into kilometers
-    velocities = j2000_rotation.rotate_velocity_at(positions, velocities, times)/1000
+    # If velocities are provided, then rotate, otherwise create array of 0s to match shape of position
+    if velocities is not None:
+        velocities = j2000_rotation.rotate_velocity_at(positions, velocities, times)/1000
+    else:
+        velocities = np.zeros(positions.shape)
     positions = j2000_rotation.apply_at(positions, times)/1000
     instrument_position['positions'] = positions
     instrument_position['velocities'] = velocities
@@ -191,7 +195,11 @@ def to_isd(driver):
     sun_position['spk_table_original_size'] = len(times)
     sun_position['ephemeris_times'] = times
     # Rotate positions and velocities into J2000 then scale into kilometers
-    velocities = j2000_rotation.rotate_velocity_at(positions, velocities, times)/1000
+    # If velocities are provided, then rotate, otherwise create array of 0s to match shape of position
+    if velocities is not None:
+        velocities = j2000_rotation.rotate_velocity_at(positions, velocities, times)/1000
+    else:
+        velocities = np.zeros(positions.shape)
     positions = j2000_rotation.apply_at(positions, times)/1000
     sun_position['positions'] = positions
     sun_position['velocities'] = velocities


### PR DESCRIPTION
## Overview
ISIS allows states to be created with no velocities.  This can be seen in InstrumentPosition and SunPosition tables, and there exists a "hasVelocity" function to test if velocities are present.

The ALE formatter does not currently allow states without velocities.  This precludes the creation of drivers for ApolloPan, because ApolloPanInit creates tables that do not contain velocities.

## Potential Issue
Ideally, the velocities that are written to the ISD would be empty lists, but this causes issues when deserializing from JSON / ISD.  The current workaround is to create np.zeros arrays that match the shape of the positions in the table. I'm not sure if specifying velocity of 0 will have side effects.  I suspect that, since this was not previously supported, it won't break anything that exists, but I'm not sure of the validity of any results using the new output.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

