### PR TITLE
Truly Fix Windows

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -120,8 +120,7 @@ jobs:
           ls D:\a\ale\ale\build\Release
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
-          name: ale
+          name: ale-py${{ matrix.python-version }}
           path: |
             D:\a\ale\ale\build\Release\ale.dll
             D:\a\ale\ale\build\Release\ale.lib
-          overwrite: true


### PR DESCRIPTION
Attempt to fix the windows builds, again

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

