### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/aws_doc_deploy.yml
+++ b/.github/workflows/aws_doc_deploy.yml
@@ -37,7 +37,7 @@ jobs:
           mkdir build
           cd build
           cmake -DCMAKE_BUILD_TYPE=RELEASE -DCOVERAGE=OFF -DALE_BUILD_TESTS=OFF -DALE_BUILD_DOCS=ON ..
-          cmake --build . --target Sphinx --config Release
+          cmake --build . --target Docs --config Release
             
       - name: Set AWS credentials for upload
         uses: aws-actions/configure-aws-credentials@0e613a0980cbf65ed5b322eb7a1e075d28913a83
@@ -47,5 +47,5 @@ jobs:
           aws-region: us-west-2
       
       - name: Upload to S3
-        working-directory: build/docs/sphinx
+        working-directory: build/docs
         run: aws s3 sync --delete public s3://asc-public-docs/software_manuals/ale/

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -87,7 +87,7 @@ jobs:
           mkdir build
           cd build
           cmake -DCMAKE_BUILD_TYPE=RELEASE -DCOVERAGE=OFF -DALE_BUILD_TESTS=OFF -DALE_BUILD_DOCS=ON ..
-          cmake --build . --target Sphinx --config Debug
+          cmake --build . --target Docs --config Debug
 
   Build-and-Test-Win:
     runs-on: windows-2019

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -34,7 +34,7 @@ add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
 add_custom_target(Doxygen ALL DEPENDS ${DOXYGEN_INDEX_FILE})
 
 set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
-set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/sphinx)
+set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/public)
 set(SPHINX_INDEX_FILE ${SPHINX_BUILD}/index.html)
 
 set(SPHINX_RST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/index.rst)
@@ -56,7 +56,7 @@ add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
 
 
 # Nice named target so we can run the job easily
-add_custom_target(Sphinx ALL DEPENDS ${SPHINX_INDEX_FILE})
+add_custom_target(Docs ALL DEPENDS ${SPHINX_INDEX_FILE})
 
 # Add an install target to install the docs
 include(GNUInstallDirs)


### PR DESCRIPTION
Fixes the ALE doc deploy workflow

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

