### PR TITLE
Cast SpkTableOriginalSize as integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ release.
 - Added the ability to generate ISDs with no velocities specified for instrument/sun position [#614](https://github.com/DOI-USGS/ale/issues/614)
 
 ### Changed
-- Changed how push frame sensor drivers compute the `ephemeris_time` property [#595](https://github.com/DOI-USGS/ale/pull/595)
+- Changed how push frame sensor drivers compute the `ephemeris_time` property [#595](https://github.com/DOI-USGS/ale/pull/595) 
 
 ### Fixed
 - Fixed landed sensors to correctly project locally [#590](https://github.com/DOI-USGS/ale/pull/590)
@@ -59,6 +59,7 @@ release.
 - Brought timing in line with ISIS for the KaguyaMiIsisLabelNaifSpiceDriver [#599](https://github.com/DOI-USGS/ale/pull/599)
 - Brought timing in line with ISIS for the MroMarciIsisLabelNaifSpiceDriver [#600](https://github.com/DOI-USGS/ale/pull/600)
 - Fixed a bug in which quaternions would flip sign in a way that caused interpolation errors [#603](https://github.com/DOI-USGS/ale/issues/603)
+- Cast SpkTableOriginalSize as an integer from a float as np.linspace() expects an integer for the `num` param.
 
 ## [0.10.0] - 2024-01-08 
 

--- a/ale/base/data_isis.py
+++ b/ale/base/data_isis.py
@@ -125,7 +125,7 @@ def rotate_state(table, rotation):
     elif 'J2000SVX' in table:
         ephemeris_times = np.linspace(table['SpkTableStartTime'],
                                       table['SpkTableEndTime'],
-                                      table['SpkTableOriginalSize'])
+                                      int(table['SpkTableOriginalSize']))
         base_time = table['J2000SVX'][-1]
         time_scale = table['J2000SVY'][-1]
         scaled_times = (ephemeris_times - base_time) / time_scale


### PR DESCRIPTION
Ran into this bug when testing the [ISIS CSM State output PR](https://github.com/DOI-USGS/ISIS3/pull/5675) where the `ale::loads()` function fails because the SpkTableOriginalSize comes in as a float when numpy's `linspace()` expects an integer type for the `num` param. The ISIS test `FunctionalTestJigsawOutputCsmState` is currently failing but should be fixed with this PR merge and a release.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

