### PR TITLE
Formate Positions and Velocities as before

### DIFF
--- a/ale/formatters/formatter.py
+++ b/ale/formatters/formatter.py
@@ -168,12 +168,12 @@ def to_isd(driver):
     instrument_position['spk_table_original_size'] = len(times)
     instrument_position['ephemeris_times'] = times
     # Rotate positions and velocities into J2000 then scale into kilometers
+    rotated_positions = j2000_rotation.apply_at(positions, times)/1000
+    instrument_position['positions'] = rotated_positions
     # If velocities are provided, then rotate and add to ISD
     if velocities is not None:
         velocities = j2000_rotation.rotate_velocity_at(positions, velocities, times)/1000
         instrument_position['velocities'] = velocities
-    positions = j2000_rotation.apply_at(positions, times)/1000
-    instrument_position['positions'] = positions
     instrument_position["reference_frame"] = j2000_rotation.dest
     
     isd['instrument_position'] = instrument_position
@@ -185,13 +185,12 @@ def to_isd(driver):
     sun_position['spk_table_original_size'] = len(times)
     sun_position['ephemeris_times'] = times
     # Rotate positions and velocities into J2000 then scale into kilometers
+    rotated_positions = j2000_rotation.apply_at(positions, times)/1000
+    sun_position['positions'] = rotated_positions
     # If velocities are provided, then rotate and add to ISD
     if velocities is not None:
         velocities = j2000_rotation.rotate_velocity_at(positions, velocities, times)/1000
         sun_position['velocities'] = velocities
-    
-    positions = j2000_rotation.apply_at(positions, times)/1000
-    sun_position['positions'] = positions
     sun_position["reference_frame"] = j2000_rotation.dest
 
     isd['sun_position'] = sun_position


### PR DESCRIPTION
Fix formatter to put positions ahead of velocities again

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

