### PR TITLE
Add driver for Chandrayaan-2 OHRC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ release.
 - Changed velocities to be after positions in ALE unified formatter for easier comparison with older ISDs [#650](https://github.com/DOI-USGS/ale/pull/650)
 - Pinned SpiceQL to 1.2.1
 
+### Added
+- Added Chandrayaan2 OHRC driver and tests [#654](https://github.com/DOI-USGS/ale/pull/654)
+
 ## [0.11.0] - 2025-04-11
 ### Changed
 - Enabled Hayabusa2 drivers [#596](https://github.com/DOI-USGS/ale/pull/596)

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -84,7 +84,7 @@ def load(label, props={}, formatter='ale', verbose=False, only_isis_spice=False,
     formatter : {'ale', 'isis', 'usgscsm'}
                 Output format for the ISD. As of 0.8.0, it is recommended that
                 the `ale` formatter is used. The `isis` and `usgscsm` formatters
-                are retrained for backwards compatability.
+                are retrained for backwards compatibility.
 
     verbose : bool
               If True, displays debug output specifying which drivers were
@@ -109,10 +109,10 @@ def load(label, props={}, formatter='ale', verbose=False, only_isis_spice=False,
     driver_mask = [only_isis_spice, only_naif_spice]
     class_list = [IsisSpice, NaifSpice]
     class_list = list(compress(class_list, driver_mask))
-    # predicat logic: make sure x is a class, who contains the word "driver" (clipper_drivers) and 
-    # the componenet classes 
-    predicat = lambda x: inspect.isclass(x) and "_driver" in x.__module__ and [i for i in class_list if i in inspect.getmro(x)] == class_list
-    driver_list = [inspect.getmembers(dmod, predicat) for dmod in __driver_modules__]
+    # predicate logic: make sure x is a class, who contains the word "driver" (clipper_drivers) and 
+    # the component classes 
+    predicate = lambda x: inspect.isclass(x) and "_driver" in x.__module__ and [i for i in class_list if i in inspect.getmro(x)] == class_list
+    driver_list = [inspect.getmembers(dmod, predicate) for dmod in __driver_modules__]
     drivers = chain.from_iterable(driver_list)
     drivers = sort_drivers([d[1] for d in drivers])
 

--- a/ale/drivers/chandrayaan_drivers.py
+++ b/ale/drivers/chandrayaan_drivers.py
@@ -38,7 +38,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
         """
         return self.spiceql_call("translateNameToCode", {"frame": "CH1", "mission": self.spiceql_mission})
 
-
     @property
     def spacecraft_name(self):
         """
@@ -50,7 +49,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
           Full name of the spacecraft
         """
         return self.label['MISSION_ID']
-
 
     @property
     def platform_name(self):
@@ -64,7 +62,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
         """
         return self.label['MISSION_NAME']
 
-
     @property
     def image_lines(self):
         """
@@ -77,7 +74,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
         """
         return self.label.get('RDN_FILE').get('RDN_IMAGE').get('LINES')
 
-
     @property
     def image_samples(self):
         """
@@ -89,7 +85,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
           Number of samples in the image
         """
         return self.label.get('RDN_FILE').get('RDN_IMAGE').get('LINE_SAMPLES')
-
 
     def read_timing_data(self):
         """
@@ -109,7 +104,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
         # Transpose such that each column is a list. Unpack and ignore anything that's not lines and times.
         self._lines, self._utc_times, *_ = zip(*lists)
 
-
     @property
     def ephemeris_start_time(self):
         """
@@ -125,7 +119,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
             self._ephemeris_start_time = self.spiceql_call("strSclkToEt", {"frameCode" : self.sensor_frame_id, "sclk" : clock_time, "mission" : self.spiceql_mission})
         return self._ephemeris_start_time 
 
-
     @property
     def ephemeris_stop_time(self):
         """
@@ -135,7 +128,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
           The stop time of the image in ephemeris seconds past the J2000 epoch.
         """
         return self.ephemeris_start_time + (self.image_lines * self.exposure_duration)
-                        
 
     @property
     def utc_time_table(self):
@@ -149,7 +141,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
             self._utc_time_table = self.label['UTC_FILE']['^UTC_TIME_TABLE']
         return self._utc_time_table
 
-
     @property
     def utc_times(self):
         """ UTC time of the center of each line
@@ -161,7 +152,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
             return list(reversed(self._utc_times))
         return self._utc_times
       
-
     @property
     def sampling_factor(self):
         """
@@ -182,7 +172,6 @@ class Chandrayaan1M3Pds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDis
         else:
             return 1
 
-                
     @property
     def line_exposure_duration(self):
         """
@@ -393,7 +382,6 @@ class Chandrayaan1MRFFRIsisLabelNaifSpiceDriver(Radar, IsisLabel, NaifSpice, Cha
           self._range_coefficients_et = [self.spiceql_call("utcToEt", {"utc": elt[0]}) for elt in range_coefficients_utc]
         return self._range_coefficients_et
 
-
     @property
     def scaled_pixel_width(self):
         """
@@ -417,7 +405,6 @@ class Chandrayaan1MRFFRIsisLabelNaifSpiceDriver(Radar, IsisLabel, NaifSpice, Cha
           scaled pixel height
         """
         return self.label['IsisCube']['Instrument']['ScaledPixelHeight']
-
 
     @property
     def look_direction(self):
@@ -505,7 +492,7 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
           ISIS sensor model version
         """
         return 1
-    
+
     @property
     def ephemeris_start_time(self):
         """
@@ -666,3 +653,243 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
                                 
         return self._frame_chain
 
+class Chandrayaan2OHRCIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice, NoDistortion, Driver):
+    
+    @property
+    def instrument_id(self):
+        """
+        Returns the instrument id for chandrayaan2 terrain mapping camera
+        
+        Returns
+        -------
+        : str
+          Frame Reference for Chandrayaan2 Orbiter High Resolution Camera
+        """
+        inst_id_lookup = {
+            "OHRC" : "CHANDRAYAAN-2 ORBITER"
+        }
+        return inst_id_lookup[super().instrument_id] 
+    
+    @property
+    def ikid(self):
+        """
+        The NAIF id for the instrument
+        Expects kernels_group to be defined. 
+        
+        Returns
+        -------
+        : int
+          ikid for chandrayaan2 terrain mapping camera
+        """
+        return self.label['IsisCube']['Kernels']['NaifFrameCode']
+    
+    @property
+    def sensor_name(self):
+        """
+        Returns the sensor name
+
+        Returns
+        -------
+        : str
+          sensor name
+        """
+        return self.instrument_id
+    
+    @property
+    def sensor_model_version(self):
+        """
+        The ISIS Sensor model number for Chandrayaan2OHRC in ISIS. This is likely just 1
+        
+        Returns
+        -------
+        : int
+          ISIS sensor model version
+        """
+        return 1
+    
+    @property
+    def ephemeris_start_time(self):
+        """
+        The spacecraft clock start count, frequently used to determine the start time
+        of the image.
+
+        Returns
+        -------
+        : str
+          Spacecraft clock start count
+        """
+        if not hasattr(self, "_ephemeris_start_time"):
+          self._ephemeris_start_time = self.spiceql_call("utcToEt", {"utc": self.utc_start_time.strftime("%Y-%m-%d %H:%M:%S.%f")})
+        return self._ephemeris_start_time
+
+    @property
+    def ephemeris_stop_time(self):
+        """
+        The spacecraft clock stop count, frequently used to determine the stop time
+        of the image.
+
+        Returns
+        -------
+        : str
+          Spacecraft clock stop count
+        """
+        if not hasattr(self, "_ephemeris_stop_time"):
+            self._ephemeris_stop_time = self.spiceql_call("utcToEt", {"utc": self.utc_stop_time.strftime("%Y-%m-%d %H:%M:%S.%f")})
+        return self._ephemeris_stop_time
+
+    @property
+    def detector_center_line(self):
+        """
+        The center of the CCD in detector pixels
+        Expects ikid to be defined. this should be the integer Naif ID code for
+        the instrument.
+
+        Returns
+        -------
+        list :
+            The line of the center of the CCD, in pixel units
+        """
+        return self.naif_keywords[f"INS{self.ikid}_CENTER"][1] 
+
+    @property
+    def detector_center_sample(self):
+        """
+        The center of the CCD in detector pixels
+        Expects ikid to be defined. this should be the integer Naif ID code for
+        the instrument.
+
+        Returns
+        -------
+        list :
+            The sample coordinate of the center of the CCD, in pixel units
+        """
+        return self.naif_keywords[f"INS{self.ikid}_CENTER"][0]
+
+    @property
+    def focal2pixel_lines(self):
+        """
+        Expects ikid to be defined. This should be an integer containing the
+        Naif ID code for the instrument.
+
+        Returns
+        -------
+        : list<double>
+          focal plane to detector lines
+        """
+        # meters to mm
+        pixel_size = self.naif_keywords[f"INS{self.ikid}_PIXEL_SIZE"] * 1000
+        return [0.0, 0.0, 1/pixel_size]
+    
+    @property
+    def focal2pixel_samples(self):
+        """
+        Expects ikid to be defined. This should be an integer containing the Naif
+        ID code of the instrument
+
+        Returns
+        -------
+        : list<double>
+          focal plane to detector samples
+        """
+        # meters to mm
+        pixel_size = self.naif_keywords[f"INS{self.ikid}_PIXEL_SIZE"] * 1000
+        return [0.0, -1/pixel_size, 0.0]
+
+    @property
+    def original_naif_sensor_frame_id(self):
+        """
+        Original sensor frame ID as defined in the Chandrayaan 2 IK kernel. A new 
+        sensor frame ID is created in the frame_chain property to represent an
+        additional rotation that takes into account the discrepancy between
+        that the Chandrayaan 2 IK kernel defines and what ISIS expects for the 
+        directions of the axes sensors. The frame chain function below
+        implements the fix.
+
+        Returns
+        -------
+        : int
+          sensor frame code from NAIF's IK kernel
+        """
+        return self.ikid
+
+    @property
+    def sensor_frame_id(self):
+        """
+        Overwrite sensor frame id to return fake frame ID as discussed in
+        original_naif_sensor_frame_id() docstring. 
+
+        Returns
+        -------
+        : int
+          Frame id that applies a correction.
+        """
+        
+        # Subtract 1000 as all ids are negative and any subsequent one usually
+        # has increasing magnitude.
+        return self.original_naif_sensor_frame_id - 1000
+
+    @property
+    def ephemeris_time(self):
+        """
+        Returns an array of times between the start/stop ephemeris times
+        based on the number of lines in the image.
+        Expects ephemeris start/stop times to be defined. These should be
+        floating point numbers containing the start and stop times of the
+        images.
+        Expects image_lines to be defined. This should be an integer containing
+        the number of lines in the image.
+
+        Returns
+        -------
+        : ndarray
+          ephemeris times split based on image lines
+        """
+
+        # Override the parent class logic, as returning the ephemeris time for
+        # every single line does not scale for Chandrayaan2 OHRC images, which
+        # can have 101075 lines. Sampling at every 10th line should be enough.
+        num = self.image_lines
+        if num > 20000:
+            num = int(float(num) / 10.0)
+        if not hasattr(self, "_ephemeris_time"):
+            self._ephemeris_time = \
+              numpy.linspace(self.ephemeris_start_time, self.ephemeris_stop_time, num + 1)
+        return self._ephemeris_time
+
+    @property
+    def frame_chain(self):
+        """
+        Returns a modified frame chain with with an additional coordinate transformation from Chandrayaan satellite to camera.
+
+        Returns
+        -------
+        : object
+          A networkx frame chain object
+        """
+        
+        if not hasattr(self, '_frame_chain'):
+        
+          nadir = self._props.get('nadir', False)
+          exact_ck_times = self._props.get('exact_ck_times', True)
+        
+          self._frame_chain = \
+           FrameChain.from_spice(sensor_frame=self.original_naif_sensor_frame_id,
+                                 target_frame=self.target_frame_id,
+                                 center_ephemeris_time=self.center_ephemeris_time,
+                                 ephemeris_times=self.ephemeris_time,
+                                 exact_ck_times= exact_ck_times,
+                                 inst_time_bias=self.instrument_time_bias)
+
+          # Fix for the the Chandrayaan2 OHRC instrument as outlined in the
+          # original_naif_sensor_frame_id() docstring. This swaps the x and z
+          # axes, and negates the y axis.
+          mat = numpy.array([[0, 0, 1],
+                             [0, -1, 0],
+                             [1, 0, 0]])
+          quats = Rotation.from_matrix(mat).as_quat()
+          rotation = ConstantRotation(quats, 
+                                      self.sensor_frame_id, 
+                                      self.original_naif_sensor_frame_id)
+          self._frame_chain.add_edge(rotation=rotation)
+
+        return self._frame_chain

--- a/ale/drivers/chandrayaan_drivers.py
+++ b/ale/drivers/chandrayaan_drivers.py
@@ -564,8 +564,9 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
         """
         # meters to mm
         pixel_size = self.naif_keywords[f"INS{self.ikid}_PIXEL_SIZE"] * 1000
-        return [0.0, 0.0, 1/pixel_size]
-    
+        #return [0.0, 0.0, 1/pixel_size] # old
+        return [0.0, 1/pixel_size, 0.0] # new
+
     @property
     def focal2pixel_samples(self):
         """
@@ -579,7 +580,8 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
         """
         # meters to mm
         pixel_size = self.naif_keywords[f"INS{self.ikid}_PIXEL_SIZE"] * 1000
-        return [0.0, -1/pixel_size, 0.0]
+        #return [0.0, -1/pixel_size, 0.0] # old
+        return [0.0, 0.0, 1/pixel_size] # new
 
     @property
     def original_naif_sensor_frame_id(self):
@@ -670,9 +672,11 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
           # Fix for the the Chandrayaan2 TMC2 instrument as outlined in the
           # original_naif_sensor_frame_id() docstring. This swaps the x and z
           # axes, and negates the y axis.
-          mat = numpy.array([[0, 0, 1],
-                             [0, -1, 0],
-                             [1, 0, 0]])
+          # old
+          #mat = numpy.array([[0, 0, 1], [0, -1, 0], [1, 0, 0]])
+          # new
+          mat = numpy.array([[0, 0, 1], [-1, 0, 0], [0, -1, 0]])
+          
           quats = Rotation.from_matrix(mat).as_quat()
           rotation = ConstantRotation(quats, 
                                       self.sensor_frame_id, 

--- a/ale/drivers/chandrayaan_drivers.py
+++ b/ale/drivers/chandrayaan_drivers.py
@@ -615,6 +615,34 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
         return self.original_naif_sensor_frame_id - 1000
 
     @property
+    def ephemeris_time(self):
+        """
+        Returns an array of times between the start/stop ephemeris times
+        based on the number of lines in the image.
+        Expects ephemeris start/stop times to be defined. These should be
+        floating point numbers containing the start and stop times of the
+        images.
+        Expects image_lines to be defined. This should be an integer containing
+        the number of lines in the image.
+
+        Returns
+        -------
+        : ndarray
+          ephemeris times split based on image lines
+        """
+
+        # Override the parent class logic, as returning the ephemeris time for
+        # every single line does not scale for Chandrayaan2 TMC images, which
+        # can have 189999 lines. Sampling at every 10th line should be enough.
+        num = self.image_lines
+        if num > 20000:
+            num = int(float(num) / 10.0)
+        if not hasattr(self, "_ephemeris_time"):
+            self._ephemeris_time = \
+              numpy.linspace(self.ephemeris_start_time, self.ephemeris_stop_time, num + 1)
+        return self._ephemeris_time
+
+    @property
     def frame_chain(self):
         """
         Returns a modified frame chain with with an additional coordinate transformation from Chandrayaan satellite to camera.

--- a/ale/formatters/formatter.py
+++ b/ale/formatters/formatter.py
@@ -140,7 +140,7 @@ def to_isd(driver):
     instrument_pointing['constant_rotation'] = constant_rotation.rotation_matrix().flatten()
     isd['instrument_pointing'] = instrument_pointing
 
-    # interiror orientation
+    # interior orientation
     isd['naif_keywords'] = driver_data["naif_keywords"]
 
     if isinstance(driver,LineScanner) or isinstance(driver, Framer) or isinstance(driver, PushFrame):

--- a/tests/pytests/data/chandrayaan2/ch2_ohr_nrp_20200827T0226453039_d_img_d18_isis3.lbl
+++ b/tests/pytests/data/chandrayaan2/ch2_ohr_nrp_20200827T0226453039_d_img_d18_isis3.lbl
@@ -1,0 +1,348 @@
+Object = IsisCube
+  Object = Core
+    StartByte   = 65537
+    Format      = Tile
+    TileSamples = 2000
+    TileLines   = 1555
+
+    Group = Dimensions
+      Samples = 12000
+      Lines   = 101075
+      Bands   = 1
+    End_Group
+
+    Group = Pixels
+      Type       = UnsignedByte
+      ByteOrder  = Lsb
+      Base       = 0.0
+      Multiplier = 1.0
+    End_Group
+  End_Object
+
+  Group = Instrument
+    SpacecraftName       = Chandrayaan-2
+    InstrumentId         = OHRC
+    TargetName           = Moon
+    StartTime            = 2020-08-27T02:26:45.3039
+    StopTime             = 2020-08-27T02:27:01.6875
+    LineExposureDuration = 0.1621 <ms>
+  End_Group
+
+  Group = Archive
+    JobId                  = OHRXXD18CHO0449302NNNN20240115656269_V1_0
+    OrbitNumber            = 4488
+    DetectorPixelWidth     = 5.2 <micrometers>
+    FocalLength            = 2080 <mm>
+    ReferenceData          = NA
+    OrbitLimbDirection     = Descending
+    SpacecraftYawDirection = True
+    SpacecraftAltitude     = 92.77437229886651 <km>
+    PixelResolution        = 0.23579019352595598 <meters/pixel>
+    Roll                   = -1 <degrees>
+    Pitch                  = -1 <degrees>
+    Yaw                    = -1 <degrees>
+    SunAzimuth             = -1 <degrees>
+    SunElevation           = -1 <degrees>
+    SolarIncidence         = -1 <degrees>
+    Projection             = NA
+    Area                   = NA
+  End_Group
+
+  Group = BandBin
+    Center = 675
+    Width  = 175
+  End_Group
+
+  Group = Kernels
+    NaifFrameCode             = -152270
+    LeapSecond                = $base/kernels/lsk/naif0012.tls
+    TargetAttitudeShape       = ($base/kernels/pck/pck00009.tpc,
+                                 $base/kernels/pck/lunar_de403_1950-2199_pa.bp-
+                                 c, $base/kernels/fk/lunarMeanEarth001.tf)
+    TargetPosition            = (Table, $base/kernels/spk/de430.bsp)
+    InstrumentPointing        = (Table,
+                                 $chandrayaan2/kernels/ck/ch2_att_27Jul2020_04-
+                                 Sep2020_v1.bc,
+                                 $chandrayaan2/kernels/fk/ch2_v01.tf)
+    Instrument                = $chandrayaan2/kernels/ik/ch2_ohr_v01.ti
+    SpacecraftClock           = $chandrayaan2/kernels/sclk/ch2_sclk_v1.tsc
+    InstrumentPosition        = (Table,
+                                 $chandrayaan2/kernels/spk/ch2_orb_31Jul2020_0-
+                                 2Sep2020_v1.bsp)
+    InstrumentAddendum        = $chandrayaan2/kernels/iak/ohrcAddendum001.ti
+    ShapeModel                = $base/dems/ldem_128ppd_Mar2011_clon180_radius-
+                                _pad.cub
+    InstrumentPositionQuality = Reconstructed
+    InstrumentPointingQuality = Reconstructed
+    CameraVersion             = 1
+    Source                    = isis
+  End_Group
+End_Object
+
+Object = Label
+  Bytes = 65536
+End_Object
+
+Object = Table
+  Name                = InstrumentPointing
+  StartByte           = 1212972489
+  Bytes               = 5200
+  Records             = 130
+  ByteOrder           = Lsb
+  TimeDependentFrames = (-152001, 1)
+  ConstantFrames      = (-152280, -152270, -152001)
+  ConstantRotation    = (6.12323399573677e-17, -1.0, -6.12323399573677e-17,
+                         0.0, 6.12323399573677e-17, -1.0, 1.0,
+                         6.12323399573677e-17, 3.74939945665464e-33)
+  CkTableStartTime    = 651767274.4866
+  CkTableEndTime      = 651767290.87086
+  CkTableOriginalSize = 101076
+  FrameTypeCode       = 3
+  Description         = "Created by spiceinit"
+  Kernels             = ($chandrayaan2/kernels/ck/ch2_att_27Jul2020_04Sep2020-
+                         _v1.bc, $chandrayaan2/kernels/fk/ch2_v01.tf)
+
+  Group = Field
+    Name = J2000Q0
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Q1
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Q2
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Q3
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = ET
+    Type = Double
+    Size = 1
+  End_Group
+End_Object
+
+Object = Table
+  Name                 = InstrumentPosition
+  StartByte            = 1212977689
+  Bytes                = 672
+  Records              = 12
+  ByteOrder            = Lsb
+  CacheType            = HermiteSpline
+  SpkTableStartTime    = 651767274.4866
+  SpkTableEndTime      = 651767290.87086
+  SpkTableOriginalSize = 101076.0
+  Description          = "Created by spiceinit"
+  Kernels              = $chandrayaan2/kernels/spk/ch2_orb_31Jul2020_02Sep202-
+                         0_v1.bsp
+
+  Group = Field
+    Name = J2000X
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Y
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Z
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000XV
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000YV
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000ZV
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = ET
+    Type = Double
+    Size = 1
+  End_Group
+End_Object
+
+Object = Table
+  Name                = BodyRotation
+  StartByte           = 1212978361
+  Bytes               = 128
+  Records             = 2
+  ByteOrder           = Lsb
+  TimeDependentFrames = (310002, 1)
+  ConstantFrames      = (310001, 310003, 310000, 310002)
+  ConstantRotation    = (0.99999987852709, -3.09789127116553e-04,
+                         3.83375135592436e-04, 3.09789421617701e-04,
+                         0.999999952015, -7.08797549693787e-07,
+                         -3.83374897618408e-04, 8.27563025111877e-07,
+                         0.9999999265115)
+  CkTableStartTime    = 651767274.4866
+  CkTableEndTime      = 651767290.87086
+  CkTableOriginalSize = 2
+  FrameTypeCode       = 6
+  Description         = "Created by spiceinit"
+  Kernels             = ($base/kernels/spk/de430.bsp,
+                         $base/kernels/pck/pck00009.tpc,
+                         $base/kernels/pck/lunar_de403_1950-2199_pa.bpc,
+                         $base/kernels/fk/lunarMeanEarth001.tf)
+  SolarLongitude      = 63.869509611213
+
+  Group = Field
+    Name = J2000Q0
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Q1
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Q2
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Q3
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = AV1
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = AV2
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = AV3
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = ET
+    Type = Double
+    Size = 1
+  End_Group
+End_Object
+
+Object = Table
+  Name                 = SunPosition
+  StartByte            = 1212978489
+  Bytes                = 112
+  Records              = 2
+  ByteOrder            = Lsb
+  CacheType            = Linear
+  SpkTableStartTime    = 651767274.4866
+  SpkTableEndTime      = 651767290.87086
+  SpkTableOriginalSize = 2.0
+  Description          = "Created by spiceinit"
+  Kernels              = $base/kernels/spk/de430.bsp
+
+  Group = Field
+    Name = J2000X
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Y
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000Z
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000XV
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000YV
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = J2000ZV
+    Type = Double
+    Size = 1
+  End_Group
+
+  Group = Field
+    Name = ET
+    Type = Double
+    Size = 1
+  End_Group
+End_Object
+
+Object = History
+  Name      = IsisCube
+  StartByte = 1212978601
+  Bytes     = 2641
+End_Object
+
+Object = OriginalXmlLabel
+  Name      = IsisCube
+  StartByte = 1212966291
+  Bytes     = 6198
+  ByteOrder = Lsb
+End_Object
+
+Object = NaifKeywords
+  BODY_CODE               = 301
+  BODY301_RADII           = (1737.4, 1737.4, 1737.4)
+  BODY_FRAME_CODE         = 310001
+  INS-152270_FOCAL_LENGTH = 2080.0
+  INS-152270_PIXEL_SIZE   = 5.2e-06
+  INS-152270_TRANSX       = (0.0, 0.0, 4.807692307692e-04)
+  INS-152270_TRANSY       = (0.0, 4.807692307692e-04, 0.0)
+  INS-152270_ITRANSS      = (0.0, 0.0, 2080.0)
+  INS-152270_ITRANSL      = (0.0, 2080.0, 0.0)
+  INS-152270_CENTER       = (6000.0, 0.5)
+  INS-152270_OD_K         = (0.0, 0.0, 0.0)
+End_Object
+End

--- a/tests/pytests/test_chandrayaan_driver.py
+++ b/tests/pytests/test_chandrayaan_driver.py
@@ -213,18 +213,37 @@ class test_chandrayaan2_tmc_isis_naif(unittest.TestCase):
     def test_short_mission_name(self):
         assert self.driver.short_mission_name == 'chandrayaan'
 
-    def test_instrument_id(self):
-        assert self.driver.instrument_id == 'CHANDRAYAAN-2 ORBITER'
-
     def test_spacecraft_name(self):
         assert self.driver.spacecraft_name == 'Chandrayaan-2'
 
-    def test_sensor_model_version(self):
-        assert self.driver.sensor_model_version == 1
+    def test_instrument_id(self):
+        assert self.driver.instrument_id == 'CHANDRAYAAN-2 ORBITER'
 
     def test_ikid(self):
         assert self.driver.ikid == -152270
 
+    def test_sensor_model_version(self):
+        assert self.driver.sensor_model_version == 1
+
     def test_light_time_correction(self):
         assert self.driver.light_time_correction == 'LT+S'
 
+    def test_ephemeris_start_time(self):
+        with patch('ale.spiceql_access.spiceql_call', side_effect=[12345]) as spiceql_call:
+            assert self.driver.ephemeris_start_time == 12345
+            calls = [call('utcToEt', {'utc': '2020-08-27 02:26:45.303900', 
+                                      'searchKernels': False}, False)]
+            spiceql_call.assert_has_calls(calls)
+
+    def test_ephemeris_stop_time(self):
+        with patch('ale.spiceql_access.spiceql_call', side_effect=[12345]) as spiceql_call:
+            assert self.driver.ephemeris_stop_time == 12345
+            calls = [call('utcToEt', {'utc': '2020-08-27 02:27:01.687500', 'searchKernels': False}, False)]
+            spiceql_call.assert_has_calls(calls)
+
+    # This test fails with an error in the code, it even though it looks that it sets
+    # properly the value that the test will then query.
+
+    # def test_detector_center_sample(self):
+    #     with patch('ale.spiceql_access.spiceql_call', side_effect=[-12345, {"frameCode": -12345}, -12345, {"INS-12345_CENTER": [2003.09]}, {}]) as spiceql_call:
+    #         assert self.driver.detector_center_sample == 2003.09

--- a/tests/pytests/test_chandrayaan_driver.py
+++ b/tests/pytests/test_chandrayaan_driver.py
@@ -204,7 +204,7 @@ class test_chandrayaan2_tmc_isis_naif(unittest.TestCase):
         assert self.driver.light_time_correction == 'LT+S'
 
 # Chandrayaan2 OHRC tests
-class test_chandrayaan2_tmc_isis_naif(unittest.TestCase):
+class test_chandrayaan2_ohrc_isis_naif(unittest.TestCase):
 
     def setUp(self):
         label = get_image_label('ch2_ohr_nrp_20200827T0226453039_d_img_d18', 'isis3')
@@ -241,9 +241,20 @@ class test_chandrayaan2_tmc_isis_naif(unittest.TestCase):
             calls = [call('utcToEt', {'utc': '2020-08-27 02:27:01.687500', 'searchKernels': False}, False)]
             spiceql_call.assert_has_calls(calls)
 
-    # This test fails with an error in the code, it even though it looks that it sets
-    # properly the value that the test will then query.
+    def test_detector_center_sample(self):
+        with patch('ale.spiceql_access.spiceql_call', 
+                   side_effect=[-152270, 
+                                {"frameCode": -152270}, 
+                                {"INS-152270_CENTER": [2003.1, 3003.2]}, {}]) as spiceql_call:
+            assert self.driver.detector_center_sample == 2003.1
+            assert self.driver.detector_center_line   == 3003.2
 
-    # def test_detector_center_sample(self):
-    #     with patch('ale.spiceql_access.spiceql_call', side_effect=[-12345, {"frameCode": -12345}, -12345, {"INS-12345_CENTER": [2003.09]}, {}]) as spiceql_call:
-    #         assert self.driver.detector_center_sample == 2003.09
+    def test_focal2pixel_lines(self):
+        with patch('ale.spiceql_access.spiceql_call', side_effect=[-152270, {"frameCode": -152270}, {"INS-152270_PIXEL_SIZE": 12}, {}]) as spiceql_call:
+            print("---value is ", self.driver.focal2pixel_lines)
+            assert self.driver.focal2pixel_lines == [0.0, 0.0, 8.333333333333333e-05]
+
+    def test_focal2pixel_samples(self):
+        with patch('ale.spiceql_access.spiceql_call', side_effect=[-152270, {"frameCode": -152270}, {"INS-152270_PIXEL_SIZE": 12}, {}]) as spiceql_call:
+            print("---value is ", self.driver.focal2pixel_samples)
+            assert self.driver.focal2pixel_samples == [0.0, -8.333333333333333e-05, 0]

--- a/tests/pytests/test_chandrayaan_driver.py
+++ b/tests/pytests/test_chandrayaan_driver.py
@@ -251,10 +251,8 @@ class test_chandrayaan2_ohrc_isis_naif(unittest.TestCase):
 
     def test_focal2pixel_lines(self):
         with patch('ale.spiceql_access.spiceql_call', side_effect=[-152270, {"frameCode": -152270}, {"INS-152270_PIXEL_SIZE": 12}, {}]) as spiceql_call:
-            print("---value is ", self.driver.focal2pixel_lines)
             assert self.driver.focal2pixel_lines == [0.0, 0.0, 8.333333333333333e-05]
 
     def test_focal2pixel_samples(self):
         with patch('ale.spiceql_access.spiceql_call', side_effect=[-152270, {"frameCode": -152270}, {"INS-152270_PIXEL_SIZE": 12}, {}]) as spiceql_call:
-            print("---value is ", self.driver.focal2pixel_samples)
             assert self.driver.focal2pixel_samples == [0.0, -8.333333333333333e-05, 0]

--- a/tests/pytests/test_chandrayaan_driver.py
+++ b/tests/pytests/test_chandrayaan_driver.py
@@ -11,7 +11,7 @@ from unittest.mock import PropertyMock, patch, call
 import json
 from conftest import get_image_label, get_image_kernels, get_isd, get_image, convert_kernels, compare_dicts
 
-from ale.drivers.chandrayaan_drivers import Chandrayaan1M3IsisLabelNaifSpiceDriver, Chandrayaan1MRFFRIsisLabelNaifSpiceDriver, Chandrayaan1M3Pds3NaifSpiceDriver, Chandrayaan2TMC2IsisLabelNaifSpiceDriver
+from ale.drivers.chandrayaan_drivers import Chandrayaan1M3IsisLabelNaifSpiceDriver, Chandrayaan1MRFFRIsisLabelNaifSpiceDriver, Chandrayaan1M3Pds3NaifSpiceDriver, Chandrayaan2TMC2IsisLabelNaifSpiceDriver, Chandrayaan2OHRCIsisLabelNaifSpiceDriver
 
 @pytest.fixture()
 def m3_kernels(scope="module", autouse=True):
@@ -199,6 +199,31 @@ class test_chandrayaan2_tmc_isis_naif(unittest.TestCase):
 
     def test_sensor_model_version(self):
         assert self.driver.sensor_model_version == 1
+
+    def test_light_time_correction(self):
+        assert self.driver.light_time_correction == 'LT+S'
+
+# Chandrayaan2 OHRC tests
+class test_chandrayaan2_tmc_isis_naif(unittest.TestCase):
+
+    def setUp(self):
+        label = get_image_label('ch2_ohr_nrp_20200827T0226453039_d_img_d18', 'isis3')
+        self.driver = Chandrayaan2OHRCIsisLabelNaifSpiceDriver(label)
+
+    def test_short_mission_name(self):
+        assert self.driver.short_mission_name == 'chandrayaan'
+
+    def test_instrument_id(self):
+        assert self.driver.instrument_id == 'CHANDRAYAAN-2 ORBITER'
+
+    def test_spacecraft_name(self):
+        assert self.driver.spacecraft_name == 'Chandrayaan-2'
+
+    def test_sensor_model_version(self):
+        assert self.driver.sensor_model_version == 1
+
+    def test_ikid(self):
+        assert self.driver.ikid == -152270
 
     def test_light_time_correction(self):
         assert self.driver.light_time_correction == 'LT+S'


### PR DESCRIPTION
This adds a driver for the Chandrayaan-2 OHRC camera. 

I validated that stereo terrain models are produced properly (https://stereopipeline.readthedocs.io/en/latest/examples/chandrayaan2.html).

This took a lot more time than expected due to quirks in both the OHRC and TMC sensors.

There is some work to do on the ISIS side, but the ALE component seems good, and this could be merged in.
 
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

