### PR TITLE
Update Windows CI Image

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -92,7 +92,7 @@ jobs:
           cmake --build . --target Docs --config Debug
 
   Build-and-Test-Win:
-    runs-on: windows-2019
+    runs-on: windows-2020
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]


### PR DESCRIPTION
[Windows 2019 image is being deprecated](https://github.com/actions/runner-images/issues/12045) very soon so we need to use a newer image.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

