### PR TITLE
Windows CI Fix

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -119,10 +119,10 @@ jobs:
           cd build
           cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -G "Visual Studio 17 2022" -A x64 -DALE_BUILD_TESTS=OFF -DALE_BUILD_DOCS=OFF ..
           cmake --build . --target ALL_BUILD --config Release
-          ls D:/a/ale/ale/build/Release
+          ls ${{ github.workspace }}/build/Release
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: ale-py${{ matrix.python-version }}
           path: |
-            D:/a/ale/ale/build/Release/ale.dll
-            D:/a/ale/ale/build/Release/ale.lib
+            ${{ github.workspace }}/build/Release/ale.dll
+            ${{ github.workspace }}/build/Release/ale.lib


### PR DESCRIPTION
Use workspace path for windows ci

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

