### PR TITLE
Adding TMC2 to lookup table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ release.
 ## [1.0.1]
 
 ### Fixed 
+- Fixed bug where generic CH2 kernels were using for TMC-2 [#672](https://github.com/DOI-USGS/ale/pull/672)
 - Fixed bug in CH-2 drivers where SpiceQL calls did not pass search for kernels or use web parameters.[#668](https://github.com/DOI-USGS/ale/pull/668)
 
 ### Changed

--- a/ale/base/__init__.py
+++ b/ale/base/__init__.py
@@ -5,6 +5,7 @@ spiceql_mission_map = {
     "CHANDRAYAAN-1_M3": "m3",
     "CHANDRAYAAN-1_MRFFR": "mrffr",
     "CHANDRAYAAN-2 ORBITER": "chandrayaan2",
+    "TMC-2" : "tmc2",
     "M3": "m3", 
     "CASSINI_ISS_NAC": "cassini",
     "CASSINI_ISS_WAC": "cassini",


### PR DESCRIPTION
TMC2 was missing, causing the driver to get generic CH-2 kernels instead. 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

