### PR TITLE
Alespiceroot guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ release.
 ### Fixed
 - Fixed Eigen 5.x compatibility by removing version constraint in CMakeLists.txt [#677](https://github.com/DOI-USGS/ale/pull/677)
 - Fixed C++ load(s) call failing when called again after throwing an error [#696](https://github.com/DOI-USGS/ale/pull/696)
-- Fixed misleading "No Such Driver for Label" from `isd_generate` when ALESPICEROOT is unset and no kernel-source flag is given. The CLI now exits early with a message naming ALESPICEROOT and the alternative flags (`--kernel`/`--search-kernels`/`--use-web-spice`/`--only-isis-spice`).
+- Fixed misleading "No Such Driver for Label" from `isd_generate` when ALESPICEROOT is unset and no kernel-source flag is given. The CLI now exits early with a message naming ALESPICEROOT and the alternative flags (`--kernel`/`--search-kernels`/`--use-web-spice`/`--only-isis-spice`). [#704](https://github.com/DOI-USGS/ale/pull/704)
 
 ## [1.1.3] - 2026-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ release.
 ### Fixed
 - Fixed Eigen 5.x compatibility by removing version constraint in CMakeLists.txt [#677](https://github.com/DOI-USGS/ale/pull/677)
 - Fixed C++ load(s) call failing when called again after throwing an error [#696](https://github.com/DOI-USGS/ale/pull/696)
+- Fixed misleading "No Such Driver for Label" from `isd_generate` when ALESPICEROOT is unset and no kernel-source flag is given. The CLI now exits early with a message naming ALESPICEROOT and the alternative flags (`--kernel`/`--search-kernels`/`--use-web-spice`/`--only-isis-spice`).
 
 ## [1.1.3] - 2026-03-12
 

--- a/ale/isd_generate.py
+++ b/ale/isd_generate.py
@@ -145,6 +145,15 @@ def main():
     )
     args = parser.parse_args()
 
+    if (not args.kernel and
+        not args.search_kernels and
+        not args.use_web_spice and
+        not args.only_isis_spice and
+        not os.environ.get('ALESPICEROOT')):
+        sys.exit("ALESPICEROOT is unset and no kernel source was provided. "
+                 "Set ALESPICEROOT (e.g. ALESPICEROOT=$ISISDATA), or pass "
+                 "--kernel/--search-kernels/--use-web-spice/--only-isis-spice.")
+
     log_level = logging.ERROR
     if args.verbose:
         log_level = logging.INFO

--- a/tests/pytests/test_isd_generate.py
+++ b/tests/pytests/test_isd_generate.py
@@ -10,10 +10,22 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+import os
+import sys
 import unittest
 from unittest.mock import call, patch
 
 import ale.isd_generate as isdg
+
+
+class TestMain(unittest.TestCase):
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch.object(sys, "argv", ["isd_generate", "dummy.cub"])
+    def test_main_errors_on_missing_alespiceroot(self):
+        with self.assertRaises(SystemExit) as ctx:
+            isdg.main()
+        self.assertIn("ALESPICEROOT", str(ctx.exception))
 
 
 class TestFile(unittest.TestCase):


### PR DESCRIPTION
This is a fix for isd_generate failing silently when ALESPICEROOT is expected but not set. 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

