### PR TITLE
Metakernel chdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ release.
 - Fixed Eigen 5.x compatibility by removing version constraint in CMakeLists.txt [#677](https://github.com/DOI-USGS/ale/pull/677)
 - Fixed C++ load(s) call failing when called again after throwing an error [#696](https://github.com/DOI-USGS/ale/pull/696)
 - Fixed misleading "No Such Driver for Label" from `isd_generate` when ALESPICEROOT is unset and no kernel-source flag is given. The CLI now exits early with a message naming ALESPICEROOT and the alternative flags (`--kernel`/`--search-kernels`/`--use-web-spice`/`--only-isis-spice`). [#704](https://github.com/DOI-USGS/ale/pull/704)
+- Fixed metakernels with relative `PATH_VALUES` (e.g. `..`) silently failing when invoked from a working directory other than the metakernel's own directory. `NaifSpice.__enter__` now `chdir`s to each metakernel's directory around `pyspiceql.load`, then restores the prior working directory.
 
 ## [1.1.3] - 2026-03-12
 

--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -34,7 +34,13 @@ class NaifSpice():
         """
         logger.debug(f"Loading kernels: {self.kernels}")
         if isinstance(self.kernels, list) and not self.use_web:
-            [pyspiceql.load(k) for k in self.kernels]
+            for k in self.kernels:
+                cwd = os.getcwd()
+                try:
+                    os.chdir(os.path.dirname(os.path.abspath(k)))
+                    pyspiceql.load(k)
+                finally:
+                    os.chdir(cwd)
         elif isinstance(self.kernels, dict) and not self.use_web and not self.search_kernels:
             self.kset = pyspiceql.KernelSet(self.kernels)
         elif not self.use_web:


### PR DESCRIPTION
For Chandrayaan-2, isd_generate needs metakernels that are portable, so without hard-coded paths. Such a metakernel file currently fails to load.

The cause: SPICE resolves a metakernel's relative PATH_VALUES against the program's current working directory at load time, not against the metakernel's own location. ALE didn't chdir to the metakernel directory before calling furnsh, so a portable `..`-style metakernel only loaded if the program happened to be invoked from `$ISISDATA/<mission>/kernels/mk/`. From any other CWD it silently failed with "No Such Driver for Label" because no kernels could be furnished.

This PR makes ALE chdir to the metakernel's directory around the load call (and restore CWD after, even on exception), so portable relative-path metakernels resolve regardless of where the program is run from.

To test, download this metakernel file:

[ch2_v01.txt](https://github.com/user-attachments/files/27499739/ch2_v01.txt)

copy it with `.tm` extension to `$ISISDATA/chandrayaan2/kernels/mk/ch2_v01.tm` then run something like:

```
conda activate isis
export ISISROOT=$CONDA_PREFIX
export ISISDATA=$HOME/path/to/isisdata
export ALESPICEROOT=$ISISDATA

isisimport from = ch2_tmc_fwd.xml to = tmc_fwd.cub
isd_generate tmc_fwd.cub
```

This should fail to work before the fix as the relative paths are not resolved currently, but should work after the fix.

Note: the related issue of metakernels with hard-coded `/usgs/cpkgs/isis3/data/...` paths (LRO, MRO, MSL — see #529 and DOI-USGS/ISIS3#5820) is being addressed separately in #703.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
