### PR TITLE
Auto-correct stale metakernel paths using ALESPICEROOT or ISISDATA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+- Auto-correct stale `/usgs/cpkgs/isis3/data` paths in metakernels using ALESPICEROOT or ISISDATA. [#703](https://github.com/DOI-USGS/ale/pull/703)
+
 ## [1.2.0] - 2026-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ release.
 ## [Unreleased]
 
 ### Fixed
-- Auto-correct stale `/usgs/cpkgs/isis3/data` paths in metakernels using ALESPICEROOT or ISISDATA. [#703](https://github.com/DOI-USGS/ale/pull/703)
+- Auto-correct stale `/usgs/cpkgs/isis3/data` paths in metakernels using ALESPICEROOT or ISISDATA. [#712](https://github.com/DOI-USGS/ale/pull/712)
 
 ## [1.2.0] - 2026-05-20
 

--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -3,8 +3,7 @@ import spiceypy as spice
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
-import logging
-import json 
+import json
 import os
 
 import numpy as np
@@ -44,7 +43,7 @@ class NaifSpice():
         elif isinstance(self.kernels, dict) and not self.use_web and not self.search_kernels:
             self.kset = pyspiceql.KernelSet(self.kernels)
         elif not self.use_web:
-            logger.warn("No kernels were specified. No kernels will be loaded.")
+            logger.warning("No kernels were specified. No kernels will be loaded.")
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -115,8 +114,9 @@ class NaifSpice():
                 if spice_root:
                     search_results = kernel_access.get_metakernels(spice_root, missions=self.short_mission_name, years=self.utc_start_time.year, versions='latest')
                     if search_results['count'] != 0:
-                        self._kernels = [search_results['data'][0]['path']]
-                        logger.debug(f"Found metakernel: {self._kernels}")
+                        logger.debug(f"Found metakernel: {search_results['data'][0]['path']}")
+                        self._kernels = kernel_access.get_kernels_from_metakernel(search_results['data'][0]['path'])
+                        logger.debug(f"Retrieved kernels: {self._kernels}")
 
                 if self._kernels == {}:
                     logger.debug("Failed to find metakernels, falling back to SpiceQL")

--- a/ale/kernel_access.py
+++ b/ale/kernel_access.py
@@ -3,6 +3,7 @@ from glob import glob
 from itertools import groupby, chain
 import os
 from os import path
+from tempfile import NamedTemporaryFile
 import re
 import warnings
 from collections.abc import Iterable
@@ -12,6 +13,7 @@ import pvl
 import json
 
 from ale import spice_root
+from ale import logger
 from ale.util import get_isis_preferences
 from ale.util import get_isis_mission_translations
 from ale.util import read_pvl
@@ -19,6 +21,58 @@ from ale.util import search_isis_db
 from ale.util import dict_merge
 from ale.util import dict_to_lower
 from ale.util import expandvars
+
+def get_kernels_from_metakernel(metakernel, new_root=spice_root,
+                                old_root='/usgs/cpkgs/isis3/data'):
+    """
+    Read a metakernel .tm file.
+
+    If it has the hard-coded /usgs/cpkgs/isis3/data path, create a temporary
+    version of this file, replace the bad path with $ALESPICEROOT or $ISISDATA,
+    then read the patched version.
+
+    Returns a single-element list, suitable for pyspiceql.load().
+
+    Parameters
+    ----------
+    metakernel : str
+        Path to the .tm metakernel file.
+    new_root : str or None
+        Replacement root (defaults to ALESPICEROOT / ISISDATA).
+    old_root : str
+        Stale root to replace (defaults to /usgs/cpkgs/isis3/data).
+
+    Returns
+    -------
+    list of str
+        Single-element list with the metakernel path.
+    """
+    if not os.path.isfile(metakernel):
+        raise FileNotFoundError(f"Metakernel not found: {metakernel}")
+
+    ext = os.path.splitext(metakernel)[1]
+    if ext.lower() != '.tm':
+        raise ValueError(
+            f"File {metakernel} does not have the .tm extension.")
+
+    if new_root is None:
+        new_root = os.environ.get('ISISDATA')
+        if new_root is not None:
+            warnings.warn(f"ALESPICEROOT not set, using ISISDATA={new_root}")
+
+    with open(metakernel, 'r') as f:
+        text = f.read()
+
+    if isinstance(new_root, str) and old_root in text:
+        corrected = text.replace(old_root, new_root)
+        tmp = NamedTemporaryFile(mode='w', suffix='.tm', delete=False)
+        tmp.write(corrected)
+        tmp.close()
+        warnings.warn(f"Fix incorrect metakernel path: "
+                      f"'{old_root}' -> '{new_root}'")
+        return [tmp.name]
+
+    return [metakernel]
 
 def get_metakernels(spice_dir=spice_root, missions=set(), years=set(), versions=set()):
     """

--- a/tests/pytests/data/kernel_access/mro_test_mk.tm
+++ b/tests/pytests/data/kernel_access/mro_test_mk.tm
@@ -1,0 +1,41 @@
+KPL/MK
+
+   This meta-kernel lists the MRO SPICE kernels providing coverage for
+   2009. All of the kernels listed below are archived in the MRO SPICE
+   data set (DATA_SET_ID = "MRO-M-SPICE-6-V1.0"). This set of files and
+   the order in which they are listed were picked to provide the best
+   available data and the most complete coverage for the specified year
+   based on the information about the kernels available at the time
+   this meta-kernel was made. For detailed information about the
+   kernels listed below refer to the internal comments included in the
+   kernels and the documentation accompanying the MRO SPICE data set.
+
+   It is recommended that users make a local copy of this file and
+   modify the value of the PATH_VALUES keyword to point to the actual
+   location of the MRO SPICE data set's ``data'' directory on their
+   system. Replacing ``/'' with ``\'' and converting line terminators
+   to the format native to the user's system may also be required if
+   this meta-kernel is to be used on a non-UNIX workstation.
+
+   This file was created on February 26, 2016 by Boris Semenov, NAIF/JPL.
+   The original name of this file was mro_2009_v11.tm.
+
+   This file was modified on July 1, 2019 by Jesse Mapel to support the MRO
+   CTX kernels available in the ISIS data area.
+
+   \begindata
+
+      PATH_VALUES     = ( '/usgs/cpkgs/isis3/data' )
+
+      PATH_SYMBOLS    = ( 'TESTKERNELS' )
+
+      KERNELS_TO_LOAD = (
+                          '$TESTKERNELS/B10_013341_1010_XN_79S172W_0.xsp'
+                          '$TESTKERNELS/B10_013341_1010_XN_79S172W_1.xsp'
+                          '$TESTKERNELS/mro_ctx_v11.ti'
+                          '$TESTKERNELS/mro_sc_psp_090526_090601_0_sliced_-74000.xc'
+                          '$TESTKERNELS/mro_sc_psp_090526_090601_1_sliced_-74000.xc'
+                          '$TESTKERNELS/mro_sclkscet_00082_65536.tsc'
+                        )
+
+   \begintext

--- a/tests/pytests/test_kernel_access.py
+++ b/tests/pytests/test_kernel_access.py
@@ -1,5 +1,7 @@
 from importlib import reload
+import os
 from os.path import join
+from pathlib import Path
 
 import pytest
 import tempfile
@@ -45,6 +47,56 @@ def pvl_four_group():
       Messenger    = $ISIS3DATA/messenger
     EndGroup
     """
+
+def test_get_kernels_from_metakernel():
+    mro_test_mk = join(Path(__file__).parent.absolute(), 'data',
+                       'kernel_access', 'mro_test_mk.tm')
+    mro_test_path = join(Path(__file__).parent.absolute(), 'data',
+                         'B10_013341_1010_XN_79S172W')
+
+    result = kernel_access.get_kernels_from_metakernel(
+        mro_test_mk, mro_test_path)
+
+    assert len(result) == 1
+    assert result[0].endswith('.tm')
+    assert result[0] != mro_test_mk
+
+    with open(result[0], 'r') as f:
+        text = f.read()
+    assert '/usgs/cpkgs/isis3/data' not in text
+    assert mro_test_path in text
+
+    os.unlink(result[0])
+
+
+def test_get_kernels_from_metakernel_no_correction(tmpdir):
+    mk_text = """KPL/MK
+\\begindata
+    PATH_VALUES  = ( '/some/valid/path' )
+    PATH_SYMBOLS = ( 'A' )
+    KERNELS_TO_LOAD = ( '$A/kernel.bsp' )
+\\begintext
+"""
+    mk_path = str(tmpdir.join('test.tm'))
+    with open(mk_path, 'w') as f:
+        f.write(mk_text)
+
+    result = kernel_access.get_kernels_from_metakernel(mk_path, '/other')
+    assert result == [mk_path]
+
+
+def test_get_kernels_from_metakernel_warns_on_correction():
+    mro_test_mk = join(Path(__file__).parent.absolute(), 'data',
+                       'kernel_access', 'mro_test_mk.tm')
+    mro_test_path = join(Path(__file__).parent.absolute(), 'data',
+                         'B10_013341_1010_XN_79S172W')
+
+    with pytest.warns(UserWarning, match="Fix incorrect metakernel path"):
+        result = kernel_access.get_kernels_from_metakernel(
+            mro_test_mk, mro_test_path)
+
+    assert len(result) == 1
+    os.unlink(result[0])
 
 def test_find_kernels(cube_kernels, tmpdir):
     ck_db = """
@@ -249,19 +301,6 @@ def test_get_metakernels_version_only_filename(tmpdir):
     assert res_msl['data'][0]['year'] == 'N/A'
     assert res_msl['data'][0]['version'] == 'v01'
 
-@pytest.mark.parametrize('search_kwargs, expected',
-    [({'years':'2009', 'versions':'v01'}, {'count':0, 'data':[]})])
-def test_get_metakernels_no_alespiceroot(monkeypatch, search_kwargs, expected):
-    with pytest.warns(UserWarning, match="Unable to search mission directories without" +
-                                        "ALESPICEROOT being set. Defaulting to empty list"):
-        search_result =  ale.kernel_access.get_metakernels(**search_kwargs)
-    print(search_result)
-    with patch.dict('os.environ', {'ALESPICEROOT': '/foo/bar'}):
-        reload(ale)
-
-        assert search_result == expected
-    reload(ale)
-    assert not ale.spice_root
 
 @pytest.mark.parametrize('search_kwargs', [{'years':'2010'}, {'years':2010}, {'years': [2010]}, {'years': ['2010']}, {'years': set(['2010', '1999', '1776'])},
     {'missions':'bar', 'versions':'v20'}, {'missions': ['bar'], 'versions':'v20'}, {'missions': 'bar', 'versions':['v20', 'v03']}, {'missions':set(['bar']),'years': 2010, 'versions': 'latest'} ])


### PR DESCRIPTION
This is a fix on top of @jrcain-usgs's pull request https://github.com/DOI-USGS/ale/pull/703 that addresses @Kelvinrr's points.

The implementation was adjusted to read the .tm file that has the hard-coded /usgs/cpkgs/isis3/data path, make a temporary copy replacing that with ALESPICEROOT (or ISISDATA if ALESPICEROOT is not set), and load the corrected .tm.

This avoids any changes to the actual run-time environment and fixes the issue at the core, which is that a lot of metakernels shipped by USGS have the hard-coded path above.

This is a long-standing issue for at least 3 years, and while there are documented workarounds the user is supposed to make, fixing this is quite important as the new Chandrayaan-2 data is able to make use of metakernels as well. This problem also affects MSL, LRO, and MRO.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.