### PR TITLE
Hirise pds3 driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ## [Unreleased]
 
+### Added
+- `MroHiRisePds3LabelNaifSpiceDriver`, a PDS3 EDR label driver for HiRISE that generates an ISD directly from a raw EDR label without requiring an ISIS cube, paralleling the existing CTX PDS3 driver. [#702](https://github.com/DOI-USGS/ale/pull/702)
+
 ### Fixed
 - Nadir velocity axis is now computed from the `INS<ikid>_TRANSX` keyword with a `[1] < [2]` index comparison, matching ISIS's `SpiceRotation::setEphemerisTimeNadir`. [#713](https://github.com/DOI-USGS/ale/pull/713)
 

--- a/ale/drivers/mro_drivers.py
+++ b/ale/drivers/mro_drivers.py
@@ -569,20 +569,19 @@ class MroHiRisePds3LabelNaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, Radia
     @property
     def spacecraft_name(self):
         """
+        HiRISE PDS3 EDR labels carry INSTRUMENT_HOST_NAME rather than
+        SPACECRAFT_NAME, so resolve the name from the base platform_name
+        (which returns INSTRUMENT_HOST_NAME for a PDS3 label).
+
         Returns
         -------
         : str
           Spacecraft name for NAIF lookups
         """
         name_lookup = {
-            'MARS_RECONNAISSANCE_ORBITER': 'MRO',
-            'MARS RECONNAISSANCE ORBITER': 'MRO',
-            'MRO': 'MRO',
+            'MARS RECONNAISSANCE ORBITER': 'MRO'
         }
-        # PDS3 HiRISE labels use INSTRUMENT_HOST_NAME, not SPACECRAFT_NAME
-        raw = self.label.get('SPACECRAFT_NAME',
-                             self.label.get('INSTRUMENT_HOST_NAME', ''))
-        return name_lookup[raw]
+        return name_lookup[super().platform_name]
 
     @property
     def sensor_name(self):
@@ -722,20 +721,6 @@ class MroHiRisePds3LabelNaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, Radia
         return self._exposure_duration
 
     @property
-    def image_samples(self):
-        """
-        Override to return science image width (excluding prefix/suffix).
-        The PDS3 label LINE_SAMPLES includes prefix and suffix bytes.
-        The actual science image for a single channel is 1024 / binning.
-
-        Returns
-        -------
-        : int
-          Number of science image samples
-        """
-        return int(self.label['IMAGE']['LINE_SAMPLES'])
-
-    @property
     def ccd_ikid(self):
         """
         Compute the CCD NAIF IK ID using the CPMM-to-CCD lookup.
@@ -766,20 +751,32 @@ class MroHiRisePds3LabelNaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, Radia
     @property
     def detector_center_line(self):
         """
+        Returns the center detector line. This mirrors
+        MroHiRiseIsisLabelNaifSpiceDriver: it is a placeholder of 0 that keeps
+        the ISD usable within ISIS but is not the true USGSCSM boresight line.
+        ISIS itself sets the detector origin/offset in the HiRise camera model
+        rather than reading these from the ISD.
+
         Returns
         -------
         : float
-          Center detector line (placeholder for ISIS compatibility)
+          Detector line of the principal point
         """
         return 0
 
     @property
     def detector_center_sample(self):
         """
+        Returns the center detector sample. This mirrors
+        MroHiRiseIsisLabelNaifSpiceDriver: it is a placeholder of 0 that keeps
+        the ISD usable within ISIS but is not the true USGSCSM boresight sample.
+        ISIS itself sets the detector origin/offset in the HiRise camera model
+        rather than reading these from the ISD.
+
         Returns
         -------
         : float
-          Center detector sample (placeholder for ISIS compatibility)
+          Detector sample of the principal point
         """
         return 0
 
@@ -812,17 +809,6 @@ class MroHiRisePds3LabelNaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, Radia
           ISIS sensor model version
         """
         return 1
-
-    @property
-    def platform_name(self):
-        """
-        Returns
-        -------
-        : str
-          Platform name
-        """
-        return self.label.get('SPACECRAFT_NAME',
-                              self.label.get('INSTRUMENT_HOST_NAME', ''))
 
 
 class MroHiRiseIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice, RadialDistortion, Driver):

--- a/ale/drivers/mro_drivers.py
+++ b/ale/drivers/mro_drivers.py
@@ -535,6 +535,296 @@ hirise_ccd_lookup = {
   13: 9
 }
 
+class MroHiRisePds3LabelNaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistortion, Driver):
+    """
+    Driver for reading HiRISE PDS3 EDR labels directly, without requiring
+    an ISIS cube.  Uses NaifSpice for ephemeris data (via SpiceQL local
+    or web service).
+
+    This enables fully ISIS-free processing from PDS EDR download to
+    map-projected GeoTIFF.
+
+    See Also
+    --------
+    MroHiRiseIsisLabelNaifSpiceDriver : equivalent driver for ISIS cube labels.
+    """
+
+    @property
+    def instrument_id(self):
+        """
+        Returns
+        -------
+        : str
+          NAIF instrument identifier
+        """
+        id_lookup = {
+            'HIRISE': 'MRO_HIRISE',
+            'HIGH RESOLUTION IMAGING SCIENCE EXPERIMENT': 'MRO_HIRISE',
+        }
+        key = super().instrument_id
+        if key not in id_lookup:
+            raise WrongInstrumentException(f"Unknown instrument id: {key}.")
+        return id_lookup[key]
+
+    @property
+    def spacecraft_name(self):
+        """
+        Returns
+        -------
+        : str
+          Spacecraft name for NAIF lookups
+        """
+        name_lookup = {
+            'MARS_RECONNAISSANCE_ORBITER': 'MRO',
+            'MARS RECONNAISSANCE ORBITER': 'MRO',
+            'MRO': 'MRO',
+        }
+        # PDS3 HiRISE labels use INSTRUMENT_HOST_NAME, not SPACECRAFT_NAME
+        raw = self.label.get('SPACECRAFT_NAME',
+                             self.label.get('INSTRUMENT_HOST_NAME', ''))
+        return name_lookup[raw]
+
+    @property
+    def sensor_name(self):
+        """
+        Returns
+        -------
+        : str
+          Sensor name
+        """
+        return "HIRISE CAMERA"
+
+    @property
+    def _inst_settings(self):
+        """Access the INSTRUMENT_SETTING_PARAMETERS group."""
+        return self.label['INSTRUMENT_SETTING_PARAMETERS']
+
+    @property
+    def _time_params(self):
+        """Access the TIME_PARAMETERS group."""
+        return self.label['TIME_PARAMETERS']
+
+    @property
+    def spacecraft_clock_start_count(self):
+        """
+        Returns
+        -------
+        : str
+          Spacecraft clock start count from PDS3 label
+        """
+        return str(self._time_params['SPACECRAFT_CLOCK_START_COUNT'])
+
+    @property
+    def spacecraft_clock_stop_count(self):
+        """
+        Returns
+        -------
+        : str
+          Spacecraft clock stop count from PDS3 label
+        """
+        count = str(self._time_params.get('SPACECRAFT_CLOCK_STOP_COUNT', 'N/A'))
+        if count == 'N/A':
+            count = None
+        return count
+
+    @property
+    def utc_start_time(self):
+        """
+        Returns
+        -------
+        : str
+          Start time from PDS3 label
+        """
+        return self._time_params['START_TIME']
+
+    @property
+    def utc_stop_time(self):
+        """
+        Returns
+        -------
+        : str
+          Stop time from PDS3 label
+        """
+        return self._time_params['STOP_TIME']
+
+    @property
+    def _cpmm_number(self):
+        return int(self._inst_settings['MRO:CPMM_NUMBER'])
+
+    @property
+    def _tdi_mode(self):
+        return int(self._inst_settings['MRO:TDI'])
+
+    @property
+    def _bin_mode(self):
+        return int(self._inst_settings['MRO:BINNING'])
+
+    @property
+    def _delta_line_timer_count(self):
+        return int(self._inst_settings['MRO:DELTA_LINE_TIMER_COUNT'])
+
+    @property
+    def line_summing(self):
+        return self._bin_mode
+
+    @property
+    def sample_summing(self):
+        return self._bin_mode
+
+    @property
+    def un_binned_rate(self):
+        """
+        Compute the un-binned line rate from DeltaLineTimerCount.
+        Matches the ISIS HiRise camera model.
+
+        Returns
+        -------
+        : float
+          Un-binned line rate in seconds
+        """
+        if not hasattr(self, "_un_binned_rate"):
+            self._un_binned_rate = (74.0 + (self._delta_line_timer_count / 16.0)) / 1000000.0
+        return self._un_binned_rate
+
+    @property
+    def ephemeris_start_time(self):
+        """
+        Compute ephemeris start time, matching the ISIS HiRise camera model.
+
+        Returns
+        -------
+        : float
+          Starting ephemeris time
+        """
+        if not hasattr(self, "_ephemeris_start_time"):
+            tdi_mode = self._tdi_mode
+            bin_mode = self._bin_mode
+            start_time = pyspiceql.strSclkToEt(frameCode=-74999,
+                                               sclk=self.spacecraft_clock_start_count,
+                                               mission=self.spiceql_mission,
+                                               searchKernels=self.search_kernels,
+                                               useWeb=self.use_web)[0]
+            start_time -= self.un_binned_rate * ((tdi_mode / 2.0) - 0.5)
+            start_time += self.un_binned_rate * ((bin_mode / 2.0) - 0.5)
+            self._ephemeris_start_time = start_time
+        return self._ephemeris_start_time
+
+    @property
+    def exposure_duration(self):
+        """
+        Returns
+        -------
+        : float
+          Exposure duration in seconds
+        """
+        if not hasattr(self, "_exposure_duration"):
+            self._exposure_duration = self.un_binned_rate * self._bin_mode
+        return self._exposure_duration
+
+    @property
+    def image_samples(self):
+        """
+        Override to return science image width (excluding prefix/suffix).
+        The PDS3 label LINE_SAMPLES includes prefix and suffix bytes.
+        The actual science image for a single channel is 1024 / binning.
+
+        Returns
+        -------
+        : int
+          Number of science image samples
+        """
+        return int(self.label['IMAGE']['LINE_SAMPLES'])
+
+    @property
+    def ccd_ikid(self):
+        """
+        Compute the CCD NAIF IK ID using the CPMM-to-CCD lookup.
+
+        Returns
+        -------
+        : int
+          CCD NAIF IK ID
+        """
+        if not hasattr(self, "_ccd_ikid"):
+            ccd_number = hirise_ccd_lookup[self._cpmm_number]
+            self._ccd_ikid = pyspiceql.translateNameToCode(frame=f"MRO_HIRISE_CCD{ccd_number}",
+                                                           mission=self.spiceql_mission,
+                                                           searchKernels=self.search_kernels,
+                                                           useWeb=self.use_web)[0]
+        return self._ccd_ikid
+
+    @property
+    def sensor_frame_id(self):
+        """
+        Returns
+        -------
+        : int
+          Hard-coded sensor frame ID (from ISIS HiRise camera model)
+        """
+        return -74690
+
+    @property
+    def detector_center_line(self):
+        """
+        Returns
+        -------
+        : float
+          Center detector line (placeholder for ISIS compatibility)
+        """
+        return 0
+
+    @property
+    def detector_center_sample(self):
+        """
+        Returns
+        -------
+        : float
+          Center detector sample (placeholder for ISIS compatibility)
+        """
+        return 0
+
+    @property
+    def naif_keywords(self):
+        """
+        Adds CCD-specific NAIF keywords to the base set.
+
+        Returns
+        -------
+        : dict
+          Combined NAIF keywords
+        """
+        if not hasattr(self, "_mrohirise_naif_keywords"):
+            self._mrohirise_naif_keywords = {
+                **super().naif_keywords,
+                **pyspiceql.findMissionKeywords(key=f"*{self.ccd_ikid}*",
+                                                mission=self.spiceql_mission,
+                                                searchKernels=self.search_kernels,
+                                                useWeb=self.use_web)[0],
+            }
+        return self._mrohirise_naif_keywords
+
+    @property
+    def sensor_model_version(self):
+        """
+        Returns
+        -------
+        : int
+          ISIS sensor model version
+        """
+        return 1
+
+    @property
+    def platform_name(self):
+        """
+        Returns
+        -------
+        : str
+          Platform name
+        """
+        return self.label.get('SPACECRAFT_NAME',
+                              self.label.get('INSTRUMENT_HOST_NAME', ''))
+
+
 class MroHiRiseIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice, RadialDistortion, Driver):
     """
     Driver for reading HiRise ISIS labels.

--- a/tests/pytests/data/PSP_001446_1790_BG12_0/PSP_001446_1790_BG12_0_pds3.lbl
+++ b/tests/pytests/data/PSP_001446_1790_BG12_0/PSP_001446_1790_BG12_0_pds3.lbl
@@ -1,0 +1,112 @@
+PDS_VERSION_ID                 = PDS3
+RECORD_TYPE                    = UNDEFINED
+
+/* Trimmed PDS3 EDR label for ALE driver testing. Source: attached label  */
+/* of PSP_001446_1790_BG12_0.IMG from the HiRISE PDS node                  */
+/* (https://hirise-pds.lpl.arizona.edu). Only the identification keywords  */
+/* and the TIME_PARAMETERS / INSTRUMENT_SETTING_PARAMETERS / IMAGE groups  */
+/* used by MroHiRisePds3LabelNaifSpiceDriver are kept; the lookup table,   */
+/* engineering, power and temperature groups and the data-object pointers  */
+/* are dropped. All retained values are verbatim from the archive label.   */
+
+/* Identification information. */
+
+DATA_SET_ID                    = "MRO-M-HIRISE-2-EDR-V1.0"
+DATA_SET_NAME                  = "MRO MARS HIGH RESOLUTION IMAGING SCIENCE
+                                 EXPERIMENT EDR V1.0"
+PRODUCER_INSTITUTION_NAME      = "UNIVERSITY OF ARIZONA"
+PRODUCER_ID                    = "UA"
+PRODUCER_FULL_NAME             = "ALFRED MCEWEN"
+OBSERVATION_ID                 = "PSP_001446_1790"
+MRO:COMMANDED_ID               = "PSP_001446_1790"
+PRODUCT_ID                     = "PSP_001446_1790_BG12_0"
+PRODUCT_VERSION_ID             = "1.0"
+SOURCE_FILE_NAME               = "4A_01_4816996600_04_0_01.DAT"
+INSTRUMENT_HOST_NAME           = "MARS RECONNAISSANCE ORBITER"
+INSTRUMENT_HOST_ID             = "MRO"
+INSTRUMENT_NAME                = "HIGH RESOLUTION IMAGING SCIENCE EXPERIMENT"
+INSTRUMENT_ID                  = "HIRISE"
+TARGET_NAME                    = "MARS"
+MISSION_PHASE_NAME             = "PRIMARY SCIENCE PHASE"
+ORBIT_NUMBER                   = 1446
+RATIONALE_DESC                 = "Medusae Fossae Formation sample"
+SOFTWARE_NAME                  = "HiRISE_Observation v2.9.2 (2.43 2006/10/01
+                                 05:41:12)"
+FLIGHT_SOFTWARE_VERSION_ID     = "IE_FSW_V4"
+
+GROUP = TIME_PARAMETERS
+
+    /* Time when power to the CPMM units was applied. */
+    MRO:ANALOG_POWER_START_TIME  = 2006-11-17T03:27:22.490
+    MRO:ANALOG_POWER_START_COUNT = "848201261:21548"
+
+    /* Time when the observation first started. */
+    MRO:OBSERVATION_START_TIME   = 2006-11-17T03:27:52.991
+    MRO:OBSERVATION_START_COUNT  = "848201291:54379"
+
+    /* Time at the beginning of the first calibration image line. */
+    MRO:CALIBRATION_START_TIME   = 2006-11-17T03:27:53.102
+    MRO:CALIBRATION_START_COUNT  = "848201291:61647"
+
+    /* Time at the beginning of the first target image line. */
+    START_TIME                   = 2006-11-17T03:27:53.116
+    SPACECRAFT_CLOCK_START_COUNT = "848201291:62546"
+
+    /* Time at the end of the last target image line. */
+    STOP_TIME                    = 2006-11-17T03:27:54.790
+    SPACECRAFT_CLOCK_STOP_COUNT  = "848201293:41165"
+
+    /* Time when the CPMM readout started. */
+    MRO:READOUT_START_TIME       = 2006-11-17T03:28:01.971
+    MRO:READOUT_START_COUNT      = "848201300:53057"
+
+    /* Time when this EDR product was created. */
+    PRODUCT_CREATION_TIME        = 2007-04-09T21:54:15
+END_GROUP = TIME_PARAMETERS
+
+GROUP = INSTRUMENT_SETTING_PARAMETERS
+    MRO:CPMM_NUMBER                 = 4
+    MRO:CHANNEL_NUMBER              = 0
+    FILTER_NAME                     = "BLUE-GREEN"
+    CENTER_FILTER_WAVELENGTH        = 500 <NANOMETERS>
+    BANDWIDTH                       = 200 <NANOMETERS>
+    MRO:SCAN_EXPOSURE_DURATION      = 83.6875 <MICROSECONDS>
+    MRO:LINE_EXPOSURE_DURATION      = 334.7500 <MICROSECONDS>
+    MRO:IMAGE_EXPOSURE_DURATION     = 1687474.7500 <MICROSECONDS>
+    MRO:DELTA_LINE_TIMER_COUNT      = 155
+    MRO:POWERED_CPMM_FLAG           = (ON, ON, ON, ON, ON, ON, ON, ON, ON, ON,
+                                      ON, ON, ON, ON)
+    MRO:BINNING                     = 4
+    MRO:TDI                         = 64
+    MRO:TRIM_LINES                  = 607
+    MRO:FOCUS_POSITION_COUNT        = 2020
+    MRO:FELICS_COMPRESSION_FLAG     = YES
+    MRO:STIMULATION_LAMP_FLAG       = (OFF, OFF, OFF)
+    MRO:HEATER_CONTROL_MODE         = "CLOSED LOOP"
+    MRO:HEATER_CONTROL_FLAG         = (ON, ON, ON, ON, ON, ON, ON, ON, ON, ON,
+                                      ON, ON, ON, ON)
+    MRO:LOOKUP_TABLE_TYPE           = "STORED"
+    MRO:LOOKUP_TABLE_MINIMUM        = -9998
+    MRO:LOOKUP_TABLE_MAXIMUM        = -9998
+    MRO:LOOKUP_TABLE_MEDIAN         = -9998
+    MRO:LOOKUP_TABLE_K_VALUE        = -9998
+    MRO:LOOKUP_TABLE_NUMBER         = 10
+END_GROUP = INSTRUMENT_SETTING_PARAMETERS
+
+/* Image data description. */
+
+OBJECT = IMAGE
+    LINES             = 5000
+    LINE_SAMPLES      = 256
+    SAMPLE_BITS       = 8
+    SAMPLE_BIT_MASK   = 2#11111111#
+    SAMPLE_TYPE       = MSB_UNSIGNED_INTEGER
+    MISSING_CONSTANT  = 16#FF#
+    LINE_PREFIX_BYTES = 18
+    LINE_SUFFIX_BYTES = 16
+    DESCRIPTION       = "Observation image data."
+END_OBJECT = IMAGE
+
+
+
+END

--- a/tests/pytests/test_mro_drivers.py
+++ b/tests/pytests/test_mro_drivers.py
@@ -9,6 +9,7 @@ import pyspiceql as psql
 import ale
 from ale.drivers.mro_drivers import MroCtxPds3LabelNaifSpiceDriver, MroCtxIsisLabelNaifSpiceDriver, MroCtxIsisLabelIsisSpiceDriver
 from ale.drivers.mro_drivers import MroHiRiseIsisLabelNaifSpiceDriver, MroMarciIsisLabelNaifSpiceDriver, MroCrismIsisLabelNaifSpiceDriver
+from ale.drivers.mro_drivers import MroHiRisePds3LabelNaifSpiceDriver
 
 from conftest import get_image, get_image_kernels, get_isd, convert_kernels, get_image_label, compare_dicts, data_root
 
@@ -223,6 +224,98 @@ class test_hirise_isis_naif(unittest.TestCase):
 
     def test_sensor_model_version(self):
         assert self.driver.sensor_model_version == 1
+
+# ========= Test hirise pds3label and naifspice driver =========
+class test_hirise_pds_naif(unittest.TestCase):
+
+    def setUp(self):
+        label = get_image_label("PSP_001446_1790_BG12_0", "pds3")
+        self.driver = MroHiRisePds3LabelNaifSpiceDriver(label)
+
+    def test_instrument_id(self):
+        assert self.driver.instrument_id == "MRO_HIRISE"
+
+    def test_spacecraft_name(self):
+        assert self.driver.spacecraft_name == "MRO"
+
+    def test_sensor_name(self):
+        assert self.driver.sensor_name == "HIRISE CAMERA"
+
+    def test_spacecraft_clock_start_count(self):
+        assert self.driver.spacecraft_clock_start_count == "848201291:62546"
+
+    def test_spacecraft_clock_stop_count(self):
+        assert self.driver.spacecraft_clock_stop_count == "848201293:41165"
+
+    def test_un_binned_rate(self):
+        assert self.driver.un_binned_rate == 0.0000836875
+
+    def test_ephemeris_start_time(self):
+        with patch('ale.drivers.mro_drivers.pyspiceql.strSclkToEt', return_value=[12345]) as strSclkToEt:
+            assert self.driver.ephemeris_start_time == 12344.997489375
+            strSclkToEt.assert_called_with(frameCode=-74999, sclk='848201291:62546', mission='hirise', searchKernels=False, useWeb=False)
+            assert strSclkToEt.call_count == 1
+
+    def test_exposure_duration(self):
+        assert self.driver.exposure_duration == 0.00033475
+
+    def test_ccd_ikid(self):
+        with patch('ale.drivers.mro_drivers.pyspiceql.translateNameToCode', return_value=[12345]) as translateNameToCode:
+            assert self.driver.ccd_ikid == 12345
+            translateNameToCode.assert_called_with(frame='MRO_HIRISE_CCD12', mission='hirise', searchKernels=False, useWeb=False)
+            assert translateNameToCode.call_count == 1
+
+    def test_sensor_frame_id(self):
+        assert self.driver.sensor_frame_id == -74690
+
+    def test_detector_center_sample(self):
+        assert self.driver.detector_center_sample == 0
+
+    def test_detector_center_line(self):
+        assert self.driver.detector_center_line == 0
+
+    def test_image_samples(self):
+        assert self.driver.image_samples == 256
+
+    def test_image_lines(self):
+        assert self.driver.image_lines == 5000
+
+    def test_sensor_model_version(self):
+        assert self.driver.sensor_model_version == 1
+
+    def test_platform_name(self):
+        assert self.driver.platform_name == "MARS RECONNAISSANCE ORBITER"
+
+# ===== HiRISE PDS3 vs ISIS driver equivalence (same observation) =====
+class test_hirise_pds_vs_isis_equivalence(unittest.TestCase):
+    """
+    The PDS3 and ISIS HiRISE drivers describe the SAME observation
+    (PSP_001446_1790_BG12_0). Given identical SpiceQL results, the properties
+    used to build the ISD must agree between the two drivers. spacecraft_name
+    is intentionally excluded: the PDS3 driver maps it to the NAIF short name
+    'MRO' while the ISIS driver returns the full 'MARS RECONNAISSANCE ORBITER';
+    both are valid for their respective downstream lookups.
+    """
+
+    def setUp(self):
+        self.pds = MroHiRisePds3LabelNaifSpiceDriver(get_image_label("PSP_001446_1790_BG12_0", "pds3"))
+        self.isis = MroHiRiseIsisLabelNaifSpiceDriver(get_image_label("PSP_001446_1790_BG12_0", "isis3"))
+
+    def test_static_properties_match(self):
+        shared = ["instrument_id", "sensor_name", "spacecraft_clock_start_count",
+                  "un_binned_rate", "exposure_duration", "image_samples",
+                  "image_lines", "sensor_frame_id", "detector_center_line",
+                  "detector_center_sample", "sensor_model_version", "spiceql_mission"]
+        for prop in shared:
+            assert getattr(self.pds, prop) == getattr(self.isis, prop), f"{prop} differs between drivers"
+
+    def test_ephemeris_start_time_match(self):
+        with patch('ale.drivers.mro_drivers.pyspiceql.strSclkToEt', return_value=[12345]):
+            assert self.pds.ephemeris_start_time == self.isis.ephemeris_start_time
+
+    def test_ccd_ikid_match(self):
+        with patch('ale.drivers.mro_drivers.pyspiceql.translateNameToCode', return_value=[999]):
+            assert self.pds.ccd_ikid == self.isis.ccd_ikid
 
 # ========= Test marci isislabel and naifspice driver =========
 class test_marci_isis_naif(unittest.TestCase):


### PR DESCRIPTION
This is a careful effort to sort out https://github.com/DOI-USGS/ale/pull/702.

The goal of that seems worthy: A PDS3 label driver for HiRISE that enables ISD generation directly from raw PDS EDR files without requiring an ISIS cube.

That is useful because HiRISE cubes are huge and hard to make, and bypassing that can greatly speed up processing. It also parallels nicely the existing CTX driver duo.

That pull request was obviously incomplete. I used Claude to fix this. The goal here is to leverage the AI to help ensure very thorough testing and careful reviewing, rather than add to the developer workload.

Here is what is changed.

Synched up to main. The SpiceQL lookups now use the pyspiceql.strSclkToEt(...) / translateNameToCode(...) / findMissionKeywords(...) calling convention already used by the sibling MroHiRiseIsisLabelNaifSpiceDriver.

Addressed all of @acpaquette's review comments:

image_samples override removed. The base Pds3Label.image_samples already returns the correct value.

detector_center_line / detector_center_sample is kept at 0 for parity with MroHiRiseIsisLabelNaifSpiceDriver.

spacecraft_name simplified. HiRISE EDR labels carry only INSTRUMENT_HOST_NAME (no SPACECRAFT_NAME), so this now resolves via name_lookup[super().platform_name], matching how MroCrismIsisLabelNaifSpiceDriver does it.

platform_name override removed. The base Pds3Label.platform_name already returns INSTRUMENT_HOST_NAME.

## Testing

Two test classes added to tests/pytests/test_mro_drivers.py, using the same scaffolding as the existing tests - conftest.get_image_label, the test-data directory layout, and mocked pyspiceql calls:

- test_hirise_pds_naif - per-property unit tests for the new driver, modeled directly on the existing test_ctx_pds_naif and test_hirise_isis_naif.

- test_hirise_pds_vs_isis_equivalence - instantiates the PDS3 driver and the ISIS-label driver MroHiRiseIsisLabelNaifSpiceDriver on the *same* observation and asserts they go through the same motions: every ISD-relevant property agrees between the two drivers (instrument id, sensor name, clock count, un-binned rate, exposure duration, image samples/lines, sensor frame, detector center, ephemeris start time, CCD ikid). spacecraft_name is excluded by design - the PDS3 driver maps it to the NAIF short name MRO while the ISIS driver keeps the full MARS RECONNAISSANCE ORBITER.

- A trimmed PDS3 EDR label fixture (data/PSP_001446_1790_BG12_0/PSP_001446_1790_BG12_0_pds3.lbl) is added - it is the *same observation* as the existing HiRISE ISIS-label fixture and kernels, so the two drivers are directly comparable. It is trimmed the same way as the existing CTX _pds3.lbl fixture, with all retained values verbatim from the archive label (HiRISE PDS node).

There are 19 new tests.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.