### PR TITLE
Fix KeyError for MEX HRSC stereo channels in spiceql_mission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ release.
 ### Fixed
 - Fixed undefined behavior in Rotation::toRotationMatrix by normalizing the quaternion before converting it to a rotation matrix. See [Eigen 3.4.1 Docs](https://libeigen.gitlab.io/eigen/docs-3.4/classEigen_1_1QuaternionBase.html#a8cf07ab9875baba2eecdd62ff93bfc3f) [#711](https://github.com/DOI-USGS/ale/pull/711)
 - Nadir velocity axis is now computed from the `INS<ikid>_TRANSX` keyword with a `[1] < [2]` index comparison, matching ISIS's `SpiceRotation::setEphemerisTimeNadir`. [#713](https://github.com/DOI-USGS/ale/pull/713)
+- Fixed `KeyError: 'MEX_HRSC_S1'` when generating an ISD for the MEX HRSC stereo channels (and any non-IR filter channel). The HRSC drivers now override `spiceql_mission` to return `hrsc`, matching the pattern used by the KPLO and Mariner drivers, instead of looking up the filter-specific instrument id in `spiceql_mission_map`, which only lists one channel. [#716](https://github.com/DOI-USGS/ale/pull/716)
 
 ## [1.2.0] - 2026-05-20
 

--- a/ale/drivers/mex_drivers.py
+++ b/ale/drivers/mex_drivers.py
@@ -163,6 +163,23 @@ class MexHrscPds3LabelNaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, NoDisto
 
 
     @property
+    def spiceql_mission(self):
+        """
+        All nine HRSC filter channels (including the stereo channels S1 and S2)
+        belong to the same SpiceQL "hrsc" mission. The instrument_id is filter
+        specific, so it cannot be used as a key into spiceql_mission_map, which
+        only lists one channel. Return the mission directly so every channel is
+        covered.
+
+        Returns
+        -------
+        : str
+          The spiceql mission string
+        """
+        return "hrsc"
+
+
+    @property
     def spacecraft_name(self):
         """
         Spacecraft name used in various SPICE calls to acquire
@@ -510,6 +527,23 @@ class MexHrscIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice, NoDisto
       if(super().instrument_id != "HRSC"):
           raise WrongInstrumentException ("Instrument ID is wrong.")
       return self.label['IsisCube']['Archive']['DetectorId']
+
+
+  @property
+  def spiceql_mission(self):
+      """
+      All nine HRSC filter channels (including the stereo channels S1 and S2)
+      belong to the same SpiceQL "hrsc" mission. The instrument_id is filter
+      specific, so it cannot be used as a key into spiceql_mission_map, which
+      only lists one channel. Return the mission directly so every channel is
+      covered.
+
+      Returns
+      -------
+      : str
+        The spiceql mission string
+      """
+      return "hrsc"
 
 
   @property

--- a/tests/pytests/test_mex_drivers.py
+++ b/tests/pytests/test_mex_drivers.py
@@ -94,6 +94,17 @@ class test_mex_pds3_naif(unittest.TestCase):
     def test_instrument_id(self):
         assert self.driver.instrument_id == 'MEX_HRSC_IR'
 
+    def test_spiceql_mission_stereo_channels(self):
+        # The stereo channels (DETECTOR_ID MEX_HRSC_S1 / MEX_HRSC_S2) are not
+        # listed in spiceql_mission_map. Before the spiceql_mission override
+        # they raised KeyError: 'MEX_HRSC_S1'. They must resolve to 'hrsc',
+        # like every other HRSC filter channel.
+        for channel in ('MEX_HRSC_S1', 'MEX_HRSC_S2'):
+            with patch.object(MexHrscPds3LabelNaifSpiceDriver, 'instrument_id',
+                              new_callable=PropertyMock) as instrument_id:
+                instrument_id.return_value = channel
+                assert self.driver.spiceql_mission == 'hrsc'
+
     def test_spacecraft_name(self):
         assert self.driver.spacecraft_name =='MEX'
 
@@ -190,6 +201,17 @@ class test_mex_isis3_naif(unittest.TestCase):
 
     def test_instrument_id(self):
         assert self.driver.instrument_id == 'MEX_HRSC_IR'
+
+    def test_spiceql_mission_stereo_channels(self):
+        # The stereo channels (DetectorId MEX_HRSC_S1 / MEX_HRSC_S2) are not
+        # listed in spiceql_mission_map. Before the spiceql_mission override
+        # they raised KeyError: 'MEX_HRSC_S1'. They must resolve to 'hrsc',
+        # like every other HRSC filter channel.
+        for channel in ('MEX_HRSC_S1', 'MEX_HRSC_S2'):
+            with patch.object(MexHrscIsisLabelNaifSpiceDriver, 'instrument_id',
+                              new_callable=PropertyMock) as instrument_id:
+                instrument_id.return_value = channel
+                assert self.driver.spiceql_mission == 'hrsc'
 
     def test_ikid(self):
         with patch('ale.drivers.mex_drivers.pyspiceql.translateNameToCode', return_value=[12345]) as translateNameToCode:


### PR DESCRIPTION
Generating a CSM ISD for the Mars Express HRSC stereo channels currently fails. isd_generate finds the correct driver (MexHrscIsisLabelNaifSpiceDriver) but it throws before producing an ISD, so ALE falls through to "No viable Driver for Label". Exercising the driver directly shows the real error:

    File ".../ale/base/data_naif.py", line 887, in spiceql_mission
        return spiceql_mission_map[self.instrument_id]
    KeyError: 'MEX_HRSC_S1'

Root cause: the HRSC head has nine filter channels, and each has its own instrument_id (the ISIS Archive/DetectorId, e.g. MEX_HRSC_S1, MEX_HRSC_S2, MEX_HRSC_RED, and so on). The spiceql_mission_map only contains MEX_HRSC_IR, so every other channel, including both stereo channels used for DEM generation, raises a KeyError in spiceql_mission. This is not a kernel problem and not a SpiceQL problem; it never reaches a SpiceQL call.

Fix: override spiceql_mission to return hrsc in both HRSC head drivers (the PDS3 and ISIS label variants), so all nine channels resolve to the same mission. This mirrors what the KPLO and Mariner drivers already do, which override spiceql_mission rather than relying on the map.

I added regression tests for both drivers in test_mex_drivers.py. Without the fix they fail with KeyError MEX_HRSC_S1; with the fix they pass. The full test_mex_drivers.py passes, 54 tests.

Reproduction (ISIS and ALE), following the HRSC example in the Ames Stereo Pipeline docs:

    # Fetch one observation's two stereo channels
    wget https://pds-geosciences.wustl.edu/mex/mex-m-hrsc-3-rdr-v4/mexhrs_4000/data/1995/h1995_0000_s13.img
    wget https://pds-geosciences.wustl.edu/mex/mex-m-hrsc-3-rdr-v4/mexhrs_4000/data/1995/h1995_0000_s23.img

    # Ingest and spiceinit
    hrsc2isis from=h1995_0000_s13.img to=h1995_0000_s13.cub
    hrsc2isis from=h1995_0000_s23.img to=h1995_0000_s23.cub
    spiceinit from=h1995_0000_s13.cub ckpredicted=true
    spiceinit from=h1995_0000_s23.cub ckpredicted=true

    # Fails on main, works with this PR.
    # Here must set -k to furnish the kernels the cube was spiceinit'd with. The bare
    # "isd_generate <cube>" command requires a prebuilt SpiceQL inventory.
    isd_generate -k h1995_0000_s13.cub -v h1995_0000_s13.cub
    isd_generate -k h1995_0000_s23.cub -v h1995_0000_s23.cub

On main, isd_generate ends with "No viable Driver for Label" for both channels; with this PR it produces h1995_0000_s13.json and h1995_0000_s23.json. The stereo-channel DetectorId values MEX_HRSC_S1 and MEX_HRSC_S2 were verified on real spiceinit'd cubs.

Prepared with Claude Code.