### PR TITLE
fix for when CLOCK_ET in gtiff is not slash separated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ release.
 - Nadir velocity axis is now computed from the `INS<ikid>_TRANSX` keyword with a `[1] < [2]` index comparison, matching ISIS's `SpiceRotation::setEphemerisTimeNadir`. [#713](https://github.com/DOI-USGS/ale/pull/713)
 - Fixed `KeyError: 'MEX_HRSC_S1'` when generating an ISD for the MEX HRSC stereo channels (and any non-IR filter channel). The HRSC drivers now override `spiceql_mission` to return `hrsc`, matching the pattern used by the KPLO and Mariner drivers, instead of looking up the filter-specific instrument id in `spiceql_mission_map`, which only lists one channel. [#716](https://github.com/DOI-USGS/ale/pull/716)
 - Fixed printing kernel info via Error message, now a debug message instead. [#717](https://github.com/DOI-USGS/ale/pull/717)
+- Fixed CLOCK_ET in GTIFFs when they are not slash-separated [#718](https://github.com/DOI-USGS/ale/pull/718)
 
 ## [1.2.0] - 2026-05-20
 

--- a/ale/base/data_isis.py
+++ b/ale/base/data_isis.py
@@ -385,12 +385,15 @@ class IsisSpice():
                     # 2040). Pad to 16 in case this happens.
                     return str(key[1]).zfill(16)
 
-            # In gtiffs, looks like:
-            # "CLOCK_ET_-236_2":{
-            #     "0072174528:989000_COMPUTED":"4a1edaaeddcbbc41"
-            # }
+            
             elif isinstance(key, str) and key.startswith('CLOCK_ET_'):
+                if key.endswith('_COMPUTED'):
+                    return str(self.naif_keywords[key]).zfill(16)
                 for subkey in self.naif_keywords[key]:
+                    # For gtiffs in gdal < 3.13, like:
+                    # "CLOCK_ET_-236_2":{
+                    #     "0072174528:989000_COMPUTED":"4a1edaaeddcbbc41"
+                    # }
                     if subkey.endswith('_COMPUTED'):
                         return str(self.naif_keywords[key][subkey]).zfill(16)
                         


### PR DESCRIPTION
Fixes #708 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

