### PR TITLE
KPLO ShadowCam: subsample the ephemeris by default (as for Chandrayaan-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ release.
 - `MroHiRisePds3LabelNaifSpiceDriver`, a PDS3 EDR label driver for HiRISE that generates an ISD directly from a raw EDR label without requiring an ISIS cube, paralleling the existing CTX PDS3 driver. [#702](https://github.com/DOI-USGS/ale/pull/702)
 - Added a catch to try correcting paths in metakernels (using spice_root) if they have been left as default. [#703](https://github.com/DOI-USGS/ale/pull/703)
 
+### Changed
+- The KPLO ShadowCam driver now subsamples the ephemeris by default (linear reduction, one sample per ~10 lines), as the Chandrayaan-2 driver does, so ISDs for the long ShadowCam strips no longer reach ~20 MB. [#719](https://github.com/DOI-USGS/ale/pull/719)
+
 ### Fixed
 - Fixed undefined behavior in Rotation::toRotationMatrix by normalizing the quaternion before converting it to a rotation matrix. See [Eigen 3.4.1 Docs](https://libeigen.gitlab.io/eigen/docs-3.4/classEigen_1_1QuaternionBase.html#a8cf07ab9875baba2eecdd62ff93bfc3f) [#711](https://github.com/DOI-USGS/ale/pull/711)
 - Nadir velocity axis is now computed from the `INS<ikid>_TRANSX` keyword with a `[1] < [2]` index comparison, matching ISIS's `SpiceRotation::setEphemerisTimeNadir`. [#713](https://github.com/DOI-USGS/ale/pull/713)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ release.
 - Added a catch to try correcting paths in metakernels (using spice_root) if they have been left as default. [#703](https://github.com/DOI-USGS/ale/pull/703)
 
 ### Changed
-- The KPLO ShadowCam driver now subsamples the ephemeris by default (linear reduction, one sample per ~10 lines), as the Chandrayaan-2 driver does, so ISDs for the long ShadowCam strips no longer reach ~20 MB. [#719](https://github.com/DOI-USGS/ale/pull/719)
+- The KPLO ShadowCam driver now subsamples the ephemeris by default (linear reduction, one sample per ~10 lines), as the Chandrayaan-2 driver does, so ISDs for the long ShadowCam strips no longer reach ~20 MB. When the driver defaults the reduction (including when the caller passes `--reduction none`, which cannot be respected for this sensor), it now prints a notice to stderr. The Chandrayaan-2 TMC-2 and OHRC drivers, which override the reduction the same way, print the same notice. [#719](https://github.com/DOI-USGS/ale/pull/719)
 
 ### Fixed
 - Fixed undefined behavior in Rotation::toRotationMatrix by normalizing the quaternion before converting it to a rotation matrix. See [Eigen 3.4.1 Docs](https://libeigen.gitlab.io/eigen/docs-3.4/classEigen_1_1QuaternionBase.html#a8cf07ab9875baba2eecdd62ff93bfc3f) [#711](https://github.com/DOI-USGS/ale/pull/711)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ release.
 - Added a catch to try correcting paths in metakernels (using spice_root) if they have been left as default. [#703](https://github.com/DOI-USGS/ale/pull/703)
 
 ### Changed
-- The KPLO ShadowCam driver now subsamples the ephemeris by default (linear reduction, one sample per ~10 lines), as the Chandrayaan-2 driver does, so ISDs for the long ShadowCam strips no longer reach ~20 MB. When the driver defaults the reduction (including when the caller passes `--reduction none`, which cannot be respected for this sensor), it now prints a notice to stderr. The Chandrayaan-2 TMC-2 and OHRC drivers, which override the reduction the same way, print the same notice. [#719](https://github.com/DOI-USGS/ale/pull/719)
+- The KPLO ShadowCam driver now subsamples the ephemeris by default (linear reduction, one sample per ~10 lines), as the Chandrayaan-2 driver does, so ISDs for the long ShadowCam strips no longer reach ~20 MB. When the driver defaults the reduction (including when the caller passes `--reduction none`, which cannot be respected for this sensor), it now logs a notice via the ale logger. The Chandrayaan-2 TMC-2 and OHRC drivers, which override the reduction the same way, log the same notice. [#719](https://github.com/DOI-USGS/ale/pull/719)
 
 ### Fixed
 - Fixed undefined behavior in Rotation::toRotationMatrix by normalizing the quaternion before converting it to a rotation matrix. See [Eigen 3.4.1 Docs](https://libeigen.gitlab.io/eigen/docs-3.4/classEigen_1_1QuaternionBase.html#a8cf07ab9875baba2eecdd62ff93bfc3f) [#711](https://github.com/DOI-USGS/ale/pull/711)

--- a/ale/drivers/chandrayaan_drivers.py
+++ b/ale/drivers/chandrayaan_drivers.py
@@ -1,8 +1,7 @@
-import sys
-
 import pyspiceql
 import spiceypy as spice
 
+from ale import logger
 from ale.base import Driver, WrongInstrumentException
 from ale.base.data_naif import NaifSpice
 from ale.base.label_isis import IsisLabel
@@ -539,11 +538,11 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
         if not hasattr(self, "_ephemeris_time"):
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
-                print("Chandrayaan-2 TMC-2: per-line ephemeris ISDs are very "
-                      "large. Defaulting reduction to 'linear'. Pass --reduction "
-                      "linear --ephem_sample_rate N to control the sampling. An "
-                      "explicit --reduction none cannot be respected for this "
-                      "sensor.", file=sys.stderr)
+                logger.info("Chandrayaan-2 TMC-2: per-line ephemeris ISDs are "
+                            "very large. Defaulting reduction to 'linear'. Pass "
+                            "--reduction linear --ephem_sample_rate N to control "
+                            "the sampling. An explicit --reduction none cannot be "
+                            "respected for this sensor.")
                 self._props['reduction'] = 'linear'
             self._ephemeris_time = super().ephemeris_time
         return self._ephemeris_time
@@ -742,11 +741,11 @@ class Chandrayaan2OHRCIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
         if not hasattr(self, "_ephemeris_time"):
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
-                print("Chandrayaan-2 OHRC: per-line ephemeris ISDs are very "
-                      "large. Defaulting reduction to 'linear'. Pass --reduction "
-                      "linear --ephem_sample_rate N to control the sampling. An "
-                      "explicit --reduction none cannot be respected for this "
-                      "sensor.", file=sys.stderr)
+                logger.info("Chandrayaan-2 OHRC: per-line ephemeris ISDs are "
+                            "very large. Defaulting reduction to 'linear'. Pass "
+                            "--reduction linear --ephem_sample_rate N to control "
+                            "the sampling. An explicit --reduction none cannot be "
+                            "respected for this sensor.")
                 self._props['reduction'] = 'linear'
             self._ephemeris_time = super().ephemeris_time
         return self._ephemeris_time

--- a/ale/drivers/chandrayaan_drivers.py
+++ b/ale/drivers/chandrayaan_drivers.py
@@ -1,3 +1,5 @@
+import sys
+
 import pyspiceql
 import spiceypy as spice
 
@@ -537,6 +539,11 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
         if not hasattr(self, "_ephemeris_time"):
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
+                print("Chandrayaan-2 TMC-2: per-line ephemeris ISDs are very "
+                      "large. Defaulting reduction to 'linear'. Pass --reduction "
+                      "linear --ephem_sample_rate N to control the sampling. An "
+                      "explicit --reduction none cannot be respected for this "
+                      "sensor.", file=sys.stderr)
                 self._props['reduction'] = 'linear'
             self._ephemeris_time = super().ephemeris_time
         return self._ephemeris_time
@@ -735,6 +742,11 @@ class Chandrayaan2OHRCIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
         if not hasattr(self, "_ephemeris_time"):
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
+                print("Chandrayaan-2 OHRC: per-line ephemeris ISDs are very "
+                      "large. Defaulting reduction to 'linear'. Pass --reduction "
+                      "linear --ephem_sample_rate N to control the sampling. An "
+                      "explicit --reduction none cannot be respected for this "
+                      "sensor.", file=sys.stderr)
                 self._props['reduction'] = 'linear'
             self._ephemeris_time = super().ephemeris_time
         return self._ephemeris_time

--- a/ale/drivers/chandrayaan_drivers.py
+++ b/ale/drivers/chandrayaan_drivers.py
@@ -538,7 +538,7 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
         if not hasattr(self, "_ephemeris_time"):
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
-                logger.info("Chandrayaan-2 TMC-2: per-line ephemeris ISDs are "
+                logger.warning("Chandrayaan-2 TMC-2: per-line ephemeris ISDs are "
                             "very large. Defaulting reduction to 'linear'. Pass "
                             "--reduction linear --ephem_sample_rate N to control "
                             "the sampling. An explicit --reduction none cannot be "
@@ -741,7 +741,7 @@ class Chandrayaan2OHRCIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
         if not hasattr(self, "_ephemeris_time"):
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
-                logger.info("Chandrayaan-2 OHRC: per-line ephemeris ISDs are "
+                logger.warning("Chandrayaan-2 OHRC: per-line ephemeris ISDs are "
                             "very large. Defaulting reduction to 'linear'. Pass "
                             "--reduction linear --ephem_sample_rate N to control "
                             "the sampling. An explicit --reduction none cannot be "

--- a/ale/drivers/chandrayaan_drivers.py
+++ b/ale/drivers/chandrayaan_drivers.py
@@ -539,10 +539,10 @@ class Chandrayaan2TMC2IsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
                 logger.warning("Chandrayaan-2 TMC-2: per-line ephemeris ISDs are "
-                            "very large. Defaulting reduction to 'linear'. Pass "
-                            "--reduction linear --ephem_sample_rate N to control "
-                            "the sampling. An explicit --reduction none cannot be "
-                            "respected for this sensor.")
+                               "very large. Defaulting reduction to 'linear'. Pass "
+                               "--reduction linear --ephem_sample_rate N to control "
+                               "the sampling. An explicit --reduction none cannot be "
+                               "respected for this sensor.")
                 self._props['reduction'] = 'linear'
             self._ephemeris_time = super().ephemeris_time
         return self._ephemeris_time
@@ -742,10 +742,10 @@ class Chandrayaan2OHRCIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
                 logger.warning("Chandrayaan-2 OHRC: per-line ephemeris ISDs are "
-                            "very large. Defaulting reduction to 'linear'. Pass "
-                            "--reduction linear --ephem_sample_rate N to control "
-                            "the sampling. An explicit --reduction none cannot be "
-                            "respected for this sensor.")
+                               "very large. Defaulting reduction to 'linear'. Pass "
+                               "--reduction linear --ephem_sample_rate N to control "
+                               "the sampling. An explicit --reduction none cannot be "
+                               "respected for this sensor.")
                 self._props['reduction'] = 'linear'
             self._ephemeris_time = super().ephemeris_time
         return self._ephemeris_time

--- a/ale/drivers/kplo_drivers.py
+++ b/ale/drivers/kplo_drivers.py
@@ -106,7 +106,7 @@ class KploShadowCamIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, D
         if not hasattr(self, "_ephemeris_time"):
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
-                logger.info("ShadowCam: per-line ephemeris ISDs are very large. "
+                logger.warning("ShadowCam: per-line ephemeris ISDs are very large. "
                             "Defaulting reduction to 'linear'. Pass --reduction "
                             "linear --ephem_sample_rate N to control the sampling. "
                             "An explicit --reduction none cannot be respected for "

--- a/ale/drivers/kplo_drivers.py
+++ b/ale/drivers/kplo_drivers.py
@@ -107,10 +107,10 @@ class KploShadowCamIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, D
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
                 logger.warning("ShadowCam: per-line ephemeris ISDs are very large. "
-                            "Defaulting reduction to 'linear'. Pass --reduction "
-                            "linear --ephem_sample_rate N to control the sampling. "
-                            "An explicit --reduction none cannot be respected for "
-                            "this sensor.")
+                               "Defaulting reduction to 'linear'. Pass --reduction "
+                               "linear --ephem_sample_rate N to control the sampling. "
+                               "An explicit --reduction none cannot be respected for "
+                               "this sensor.")
                 self._props['reduction'] = 'linear'
             self._ephemeris_time = super().ephemeris_time
         return self._ephemeris_time

--- a/ale/drivers/kplo_drivers.py
+++ b/ale/drivers/kplo_drivers.py
@@ -1,9 +1,8 @@
-import sys
-
 import numpy as np
 import spiceypy as spice
 from pyspiceql import pyspiceql
 
+from ale import logger
 from ale.base import Driver, WrongInstrumentException
 from ale.base.data_naif import NaifSpice
 from ale.base.label_isis import IsisLabel
@@ -107,11 +106,11 @@ class KploShadowCamIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, D
         if not hasattr(self, "_ephemeris_time"):
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
-                print("ShadowCam: per-line ephemeris ISDs are very large. "
-                      "Defaulting reduction to 'linear'. Pass --reduction linear "
-                      "--ephem_sample_rate N to control the sampling. An explicit "
-                      "--reduction none cannot be respected for this sensor.",
-                      file=sys.stderr)
+                logger.info("ShadowCam: per-line ephemeris ISDs are very large. "
+                            "Defaulting reduction to 'linear'. Pass --reduction "
+                            "linear --ephem_sample_rate N to control the sampling. "
+                            "An explicit --reduction none cannot be respected for "
+                            "this sensor.")
                 self._props['reduction'] = 'linear'
             self._ephemeris_time = super().ephemeris_time
         return self._ephemeris_time

--- a/ale/drivers/kplo_drivers.py
+++ b/ale/drivers/kplo_drivers.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import spiceypy as spice
 from pyspiceql import pyspiceql
@@ -105,6 +107,11 @@ class KploShadowCamIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, D
         if not hasattr(self, "_ephemeris_time"):
             reduction = self._props.get('reduction', 'none').lower()
             if (reduction == 'none'):
+                print("ShadowCam: per-line ephemeris ISDs are very large. "
+                      "Defaulting reduction to 'linear'. Pass --reduction linear "
+                      "--ephem_sample_rate N to control the sampling. An explicit "
+                      "--reduction none cannot be respected for this sensor.",
+                      file=sys.stderr)
                 self._props['reduction'] = 'linear'
             self._ephemeris_time = super().ephemeris_time
         return self._ephemeris_time

--- a/ale/drivers/kplo_drivers.py
+++ b/ale/drivers/kplo_drivers.py
@@ -89,6 +89,27 @@ class KploShadowCamIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, D
         return self._ephemeris_start_time
 
     @property
+    def ephemeris_time(self):
+        """
+        Forces a reduced set of ephemeris data for ShadowCam. Images can be
+        ~85K lines long, producing per-line ephemeris ISDs that are far too
+        large (tens of MB) to load efficiently into the CSM. Subsample by
+        default (reduction=linear), unless overridden via props. Mirrors the
+        Chandrayaan-2 driver, which has the same large-ISD problem.
+
+        Returns
+        -------
+        : ndarray
+            ephemeris times, subsampled by default
+        """
+        if not hasattr(self, "_ephemeris_time"):
+            reduction = self._props.get('reduction', 'none').lower()
+            if (reduction == 'none'):
+                self._props['reduction'] = 'linear'
+            self._ephemeris_time = super().ephemeris_time
+        return self._ephemeris_time
+
+    @property
     def exposure_duration(self):
         line_rate = self.label['IsisCube']['Instrument']['LineRate']
         try:

--- a/tests/pytests/test_kplo_drivers.py
+++ b/tests/pytests/test_kplo_drivers.py
@@ -6,6 +6,7 @@ import numpy as np
 from conftest import get_image_label
 
 from ale.drivers.kplo_drivers import KploShadowCamIsisLabelNaifSpiceDriver
+from ale.base.type_sensor import LineScanner
 
 
 # Tests for the KPLO ShadowCam ISIS-label / NAIF-SPICE driver.
@@ -99,6 +100,25 @@ class test_kplo_shadowcam_isis_naif(unittest.TestCase):
             assert call.kwargs['frameCode'] == -155
             assert call.kwargs['sclk'] == '1301:2967424'
             assert call.kwargs['mission'] == 'kplo'
+
+    def test_ephemeris_reduction_defaults_to_linear(self):
+        # ShadowCam strips are tens of thousands of lines long, so the driver
+        # subsamples the ephemeris by default to keep the ISD small, the same
+        # way the Chandrayaan-2 driver does. Verify the ephemeris_time override
+        # defaults the reduction to "linear", and overrides an explicit "none".
+        # The base ephemeris_time is mocked, so no SPICE kernels are needed.
+        with patch.object(LineScanner, 'ephemeris_time',
+                          new_callable=PropertyMock, return_value=[0.0, 1.0]):
+            _ = self.driver.ephemeris_time
+        assert self.driver._props.get('reduction') == 'linear'
+
+        d = KploShadowCamIsisLabelNaifSpiceDriver(
+            get_image_label('M074289249SE', 'isis3'))
+        d._props['reduction'] = 'none'
+        with patch.object(LineScanner, 'ephemeris_time',
+                          new_callable=PropertyMock, return_value=[0.0]):
+            _ = d.ephemeris_time
+        assert d._props.get('reduction') == 'linear'
 
 # Test naif_keywords-reading properties
 class test_kplo_shadowcam_naif_keywords_properties(unittest.TestCase):


### PR DESCRIPTION
The KPLO ShadowCam driver writes one ephemeris and rotation sample per image line. ShadowCam strips are long: a typical strip is about 85,000 lines (the two test scenes are 3144 x 84992), so the CSM ISD comes out around 19 to 20 MB. That is slow to write and to load, and finer than the smoothly varying spacecraft trajectory needs.

The Chandrayaan-2 driver (TMC-2 and OHRC, images near 200,000 lines) handles this by overriding `ephemeris_time()` to default the reduction to "linear", so the ISD is subsampled unless the caller asks otherwise. It may make sense to do the same in the KPLO ShadowCam driver.

This was checked on a stereo pair, M074289249SE and M074296291SE. Each ISD was generated at full resolution, and then reduced by a factor of 10 (about 19 MB down to about 2 MB). cam_test comparing the two cameras gave a maximum pixel difference of 1.05e-04 for M074289249SE and 1.08e-04 for M074296291SE:

    cam_test --image M074289249SE.cub --cam1 M074289249SE_full.json --cam2 M074289249SE_reduced.json
    cam_test --image M074296291SE.cub --cam1 M074296291SE_full.json --cam2 M074296291SE_reduced.json

Bundle adjustment and stereo on the same pair gave very close results at full resolution and reduced (the same convergence and outlier behavior, and DEMs within stereo noise).

This PR also adds a unit test, `tests/pytests/test_kplo_drivers.py::test_ephemeris_reduction_defaults_to_linear`, which mocks the base `ephemeris_time` and verifies the driver defaults the reduction to "linear" (and overrides an explicit "none"). It needs no kernels, matching the existing mocked driver tests. A CHANGELOG entry is included, and all CI checks pass.

On the interaction with the `isd_generate --reduction` option: as with Chandrayaan-2, the driver only sets the default when the caller leaves `--reduction` at "none", so the default output is subsampled. An explicit `--reduction none` is overridden for this dataset, and `--reduction linear --ephem_sample_rate N` is still respected, so a caller can resample more or less if desired.

Developed with AI (Claude) assistance.
