### PR TITLE
testing - bumping pyspiceql

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - networkx
   - nlohmann_json
   - numpy
-  - spiceql>=1.3.0
+  - spiceql>=1.4.1
   - pvl
   - pytest
   - pytest-cov


### PR DESCRIPTION
forcing spiceql version to test new release, re-running the main tests are not picking it up for whatever reason. 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

