### PR TITLE
Fix metakernel lookup for isd_generate for CaSSIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ release.
 - Fixed `KeyError: 'MEX_HRSC_S1'` when generating an ISD for the MEX HRSC stereo channels (and any non-IR filter channel). The HRSC drivers now override `spiceql_mission` to return `hrsc`, matching the pattern used by the KPLO and Mariner drivers, instead of looking up the filter-specific instrument id in `spiceql_mission_map`, which only lists one channel. [#716](https://github.com/DOI-USGS/ale/pull/716)
 - Fixed printing kernel info via Error message, now a debug message instead. [#717](https://github.com/DOI-USGS/ale/pull/717)
 - Fixed CLOCK_ET in GTIFFs when they are not slash-separated [#718](https://github.com/DOI-USGS/ale/pull/718)
+- Fixed the metakernel lookup so `isd_generate` works out of the box for TGO CaSSIS: `get_metakernels` now reads the year and version from a filename by pattern (fixing multi-segment names such as OSIRIS-REx `orx_noola_2020_v06` and the TGO observation-vs-planning selection), and `get_kernels_from_metakernel` resolves a relative `PATH_VALUES` against the metakernel's own directory. [#725](https://github.com/DOI-USGS/ale/pull/725)
 
 ## [1.2.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ release.
 - Fixed `KeyError: 'MEX_HRSC_S1'` when generating an ISD for the MEX HRSC stereo channels (and any non-IR filter channel). The HRSC drivers now override `spiceql_mission` to return `hrsc`, matching the pattern used by the KPLO and Mariner drivers, instead of looking up the filter-specific instrument id in `spiceql_mission_map`, which only lists one channel. [#716](https://github.com/DOI-USGS/ale/pull/716)
 - Fixed printing kernel info via Error message, now a debug message instead. [#717](https://github.com/DOI-USGS/ale/pull/717)
 - Fixed CLOCK_ET in GTIFFs when they are not slash-separated [#718](https://github.com/DOI-USGS/ale/pull/718)
-- Fixed the metakernel lookup so `isd_generate` works out of the box for TGO CaSSIS: `get_metakernels` now reads the year and version from a filename by pattern (fixing multi-segment names such as OSIRIS-REx `orx_noola_2020_v06` and the TGO observation-vs-planning selection), and `get_kernels_from_metakernel` resolves a relative `PATH_VALUES` against the metakernel's own directory. [#725](https://github.com/DOI-USGS/ale/pull/725)
+- Fixed the metakernel lookup so `isd_generate` works out of the box for TGO CaSSIS: `get_metakernels` now reads the year and version from a filename by pattern (fixing multi-segment names such as OSIRIS-REx `orx_noola_2020_v06`) and skips forecast/planning metakernels (`predicted`, `plan`, `flip`) so the observation metakernel is selected, and `get_kernels_from_metakernel` resolves a relative `PATH_VALUES` against the metakernel's own directory. [#725](https://github.com/DOI-USGS/ale/pull/725)
 
 ## [1.2.0] - 2026-05-20
 

--- a/ale/kernel_access.py
+++ b/ale/kernel_access.py
@@ -246,6 +246,13 @@ def get_metakernels(spice_dir=spice_root, missions=set(), years=set(), versions=
             # 'noola', version '2020'). Year = a 4- or 8-digit segment (YYYY or
             # YYYYMMDD); version = a v<N> segment; either may be absent ('N/A').
             segments = path.splitext(path.basename(k))[0].split('_')
+            # Skip forecast/planning metakernels (predicted, planning, plan, flip):
+            # they list predicted kernels and are never the right source for an ISD
+            # of archived data. Otherwise such a name (e.g. CH1_PREDICTED_V00 or
+            # em16_plan) can tie with, and be chosen over, the observation metakernel.
+            if any(s.lower() in ('predicted', 'planning', 'plan', 'flip')
+                   for s in segments):
+                continue
             year = next((s for s in segments
                          if re.fullmatch(r'\d{4}(\d{4})?', s)), 'N/A')
             version = next((s for s in reversed(segments)

--- a/ale/kernel_access.py
+++ b/ale/kernel_access.py
@@ -120,10 +120,18 @@ def get_kernels_from_metakernel(metakernel, new_root=spice_root, old_root='/usgs
                 spiceroot_paths[key] = re.sub(old_root, new_root, path_values[index])
 
     # Check default mk paths for kernels
+    mk_dir = os.path.dirname(os.path.abspath(metakernel))
     for kernel in listed_kernels:
         default_kernel = kernel
         for symbol, path in default_paths.items():
             default_kernel = default_kernel.replace('$' + symbol, path)
+
+        # PATH_VALUES may be relative (e.g. '..' in ESA-style metakernels). SPICE
+        # resolves these against the metakernel's own directory, not the current
+        # working directory. Anchor relative paths to the metakernel dir so they
+        # resolve regardless of where ALE is invoked from.
+        if not os.path.isabs(default_kernel):
+            default_kernel = os.path.normpath(os.path.join(mk_dir, default_kernel))
 
         if os.path.isfile(default_kernel):
             default_kernels.append(default_kernel)
@@ -228,23 +236,23 @@ def get_metakernels(spice_dir=spice_root, missions=set(), years=set(), versions=
 
         metakernels = []
         for k in metakernel_paths:
-            # mission_year_version filename pattern. When only one segment
-            # follows the mission (e.g. 'lro_2013.tm' or 'ch2_v01.tm'), decide
-            # whether that segment is a year or a version: a 4-digit numeric
-            # segment is treated as the year (insert N/A in the version slot);
-            # anything else is treated as a version (insert N/A in the year
-            # slot, the legacy behavior). This makes 'lro_2013' parse as
-            # year='2013', version='N/A' so versions='latest' picks the right
-            # year, while preserving 'ch2_v01' as year='N/A', version='v01'
-            # so it still matches any-year filter.
-            components = path.splitext(path.basename(k))[0].split('_') + [k]
-            if len(components) == 3:
-                if re.fullmatch(r'\d{4}', components[1]):
-                    components.insert(2, 'N/A')
-                else:
-                    components.insert(1, 'N/A')
-
-            metakernels.append(dict(zip(metakernel_keys, components)))
+            # Extract year and version by PATTERN, not by fixed position.
+            # Metakernel names vary in how many segments precede year/version:
+            #   lro_2013, lro_2013_v01, ch2_v01,
+            #   orx_noola_2020_v06             (mission_instrument_year_version),
+            #   em16_cassis_v533_20250325_002  (ESA: name_version_date_build).
+            # A positional split mis-parses any name with more than
+            # mission_year_version segments (e.g. orx_noola_2020_v06 -> year
+            # 'noola', version '2020'). Year = a 4- or 8-digit segment (YYYY or
+            # YYYYMMDD); version = a v<N> segment; either may be absent ('N/A').
+            segments = path.splitext(path.basename(k))[0].split('_')
+            year = next((s for s in segments
+                         if re.fullmatch(r'\d{4}(\d{4})?', s)), 'N/A')
+            version = next((s for s in reversed(segments)
+                            if re.fullmatch(r'[vV]\d+', s)), 'N/A')
+            mission = segments[0] if segments else 'N/A'
+            metakernels.append({'mission': mission, 'year': year,
+                                'version': version, 'path': k})
 
         # naive filter, do we really need anything else?
         if years:
@@ -252,7 +260,8 @@ def get_metakernels(spice_dir=spice_root, missions=set(), years=set(), versions=
         if versions:
             if versions == 'latest':
                 latest = []
-                # Panda's groupby is overrated
+                # groupby only groups consecutive equal keys, so sort by year first
+                metakernels = sorted(metakernels, key=lambda x: x['year'])
                 for k, g in groupby(metakernels, lambda x:x['year']):
                     items = list(g)
                     latest.append(max(items, key=lambda x:x['version']))

--- a/tests/pytests/test_kernel_access.py
+++ b/tests/pytests/test_kernel_access.py
@@ -348,6 +348,7 @@ def test_get_metakernels_all_isisdata_shapes(tmpdir):
       mission_year                      lro_2013
       mission_year_VERSION (upper V)    lro_2009_V04
       mission_version (no year)         msl_v01
+      mission_body_provider_m<N>_v<N>   dawn_ceres_dlr_m135_v1  (Dawn, no year)
       SEMANTIC (no year, no version)    MEX_OPS, ROS_OPS, SMART1_OPS, em16_cassis
       SEMANTIC_Vver_date_build (5 seg)  MEX_OPS_V324_20250321_001, em16_cassis_v533_20250325_002
       MISSION_PREDICTED_Vver            CH1_PREDICTED_V00  (skipped)
@@ -364,6 +365,7 @@ def test_get_metakernels_all_isisdata_shapes(tmpdir):
     mk('orx',    'orx_2016_v01.tm', 'orx_noola_2020_v01.tm', 'orx_noola_2020_v06.tm')
     mk('lro',    'lro_2013.tm', 'lro_2018.tm', 'lro_2009_V02.tm', 'lro_2009_V04.tm')
     mk('msl',    'msl_v01.tm')
+    mk('dawn',   'dawn_ceres_dlr_m135_v1.tm', 'dawn_ceres_grv_m100_v1.tm', 'dawn_vesta_grv_m50_v1.tm')
     mk('mex',    'MEX_OPS.TM', 'MEX_OPS_V324_20250321_001.TM')
     mk('ros',    'ROS_OPS.TM', 'ROS_OPS_V350_20220906_001.TM')
     mk('smart1', 'SMART1_OPS.TM')
@@ -383,6 +385,7 @@ def test_get_metakernels_all_isisdata_shapes(tmpdir):
     assert pick('lro', 2013)    == 'lro_2013.tm'              # year-only
     assert pick('lro', 2009)    == 'lro_2009_V04.tm'          # uppercase version
     assert pick('msl', 2023)    == 'msl_v01.tm'               # version-only (year N/A)
+    assert pick('dawn', 2015).startswith('dawn_')            # body/product name, no year
     assert pick('mex', 2005)    == 'MEX_OPS.TM'               # generic over dated snapshot
     assert pick('ros', 2005)    == 'ROS_OPS.TM'
     assert pick('smart1', 2005) == 'SMART1_OPS.TM'            # single semantic metakernel

--- a/tests/pytests/test_kernel_access.py
+++ b/tests/pytests/test_kernel_access.py
@@ -334,50 +334,67 @@ def test_get_metakernels_search_counts(tmpdir, search_kwargs, expected_count):
     search_result =  kernel_access.get_metakernels(str(tmpdir), **search_kwargs)
     assert search_result['count'] == expected_count
 
-def test_get_metakernels_multisegment_filename(tmpdir):
-    """Metakernel names with more segments than mission_year_version must still
-    parse. OSIRIS-REx uses mission_instrument_year_version ('orx_noola_2020_v06');
-    the old positional split mis-parsed these as year='noola', version='2020'.
-    Year is the 4- or 8-digit segment and version the v<N> segment, wherever they
-    appear in the name.
+def test_get_metakernels_all_isisdata_shapes(tmpdir):
+    """Regression coverage for every metakernel name shape seen in a real ISISDATA.
+    There is no formal metakernel naming standard, so this exercises each observed
+    form with a real example. Pure filename stubs (no SPICE, no kernels). Confirms
+    the year and version are read by pattern (not by fixed position), forecast and
+    planning metakernels (predicted, plan, flip) are skipped, and the observation
+    metakernel is selected.
+
+    Shapes covered (one real example each):
+      mission_year_version              mro_2005_v08, msgr_2004_v13
+      mission_subset_year_version       orx_noola_2020_v06
+      mission_year                      lro_2013
+      mission_year_VERSION (upper V)    lro_2009_V04
+      mission_version (no year)         msl_v01
+      SEMANTIC (no year, no version)    MEX_OPS, ROS_OPS, SMART1_OPS, em16_cassis
+      SEMANTIC_Vver_date_build (5 seg)  MEX_OPS_V324_20250321_001, em16_cassis_v533_20250325_002
+      MISSION_PREDICTED_Vver            CH1_PREDICTED_V00  (skipped)
+      MISSION_Vver                      CH1_V00
+      planning / flip                   em16_plan, em16_flip (skipped)
     """
-    tmpdir.mkdir('orx-b-v01')
-    for year in ('2019', '2020'):
-        for ver in ('v01', 'v06'):
-            open(tmpdir.join('orx-b-v01', f'orx_noola_{year}_{ver}.tm'), 'w').close()
+    def mk(mission, *names):
+        d = tmpdir.mkdir(mission).mkdir('kernels').mkdir('mk')
+        for n in names:
+            open(d.join(n), 'w').close()
 
-    res = kernel_access.get_metakernels(str(tmpdir), missions='orx',
-                                        years=2020, versions='latest')
-    assert res['count'] == 1
-    assert res['data'][0]['path'].endswith('orx_noola_2020_v06.tm')
-    assert res['data'][0]['year'] == '2020'
-    assert res['data'][0]['version'] == 'v06'
+    mk('mro',    'mro_2005_v01.tm', 'mro_2005_v08.tm')
+    mk('msgr',   'msgr_2004_v08.tm', 'msgr_2004_v13.tm')
+    mk('orx',    'orx_2016_v01.tm', 'orx_noola_2020_v01.tm', 'orx_noola_2020_v06.tm')
+    mk('lro',    'lro_2013.tm', 'lro_2018.tm', 'lro_2009_V02.tm', 'lro_2009_V04.tm')
+    mk('msl',    'msl_v01.tm')
+    mk('mex',    'MEX_OPS.TM', 'MEX_OPS_V324_20250321_001.TM')
+    mk('ros',    'ROS_OPS.TM', 'ROS_OPS_V350_20220906_001.TM')
+    mk('smart1', 'SMART1_OPS.TM')
+    mk('ch1',    'CH1_V00.TM', 'CH1_PREDICTED_V00.TM')
+    mk('tgo',    'em16_cassis.tm', 'em16_ops.tm', 'em16_plan.tm', 'em16_flip.tm',
+                 'em16_cassis_v533_20250325_002.tm', 'em16_plan_v533_20250318_001.tm')
 
+    def pick(m, y):
+        r = kernel_access.get_metakernels(str(tmpdir), missions=m, years=y, versions='latest')
+        got = [os.path.basename(d['path']) for d in r['data']]
+        assert r['count'] == 1, f"{m} {y}: expected one metakernel, got {got}"
+        return got[0]
 
-def test_get_metakernels_semantic_tgo(tmpdir):
-    """TGO ships semantic metakernels (em16_cassis/ops/plan/flip) plus build-dated
-    variants (em16_cassis_v533_20250325_002.tm). The observation metakernel
-    (em16_cassis) must be selected, not the planning one; the old parser set
-    version='plan' and picked em16_plan via max(). The build-dated variant must
-    parse its 8-digit build date as the year, not leak a filename fragment into
-    the 'path' field.
-    """
-    mk = tmpdir.mkdir('tgo').mkdir('kernels').mkdir('mk')
-    for n in ('em16_cassis', 'em16_ops', 'em16_plan', 'em16_flip',
-              'em16_cassis_v533_20250325_002', 'em16_plan_v533_20250318_001'):
-        open(mk.join(f'{n}.tm'), 'w').close()
+    assert pick('mro', 2005)    == 'mro_2005_v08.tm'          # latest version wins
+    assert pick('msgr', 2004)   == 'msgr_2004_v13.tm'
+    assert pick('orx', 2020)    == 'orx_noola_2020_v06.tm'    # 4-segment name
+    assert pick('lro', 2013)    == 'lro_2013.tm'              # year-only
+    assert pick('lro', 2009)    == 'lro_2009_V04.tm'          # uppercase version
+    assert pick('msl', 2023)    == 'msl_v01.tm'               # version-only (year N/A)
+    assert pick('mex', 2005)    == 'MEX_OPS.TM'               # generic over dated snapshot
+    assert pick('ros', 2005)    == 'ROS_OPS.TM'
+    assert pick('smart1', 2005) == 'SMART1_OPS.TM'            # single semantic metakernel
+    assert pick('ch1', 2009)    == 'CH1_V00.TM'               # predicted is skipped
+    assert pick('tgo', 2018)    == 'em16_cassis.tm'           # planning and flip skipped
 
-    res = kernel_access.get_metakernels(str(tmpdir), missions='tgo',
-                                        years=2018, versions='latest')
-    assert res['count'] == 1
-    assert os.path.basename(res['data'][0]['path']) == 'em16_cassis.tm'
-
-    # the build-dated variant parses without corrupting the path field
+    # build-dated variants parse without corrupting the path field: the 8-digit
+    # build date is read as the year, the v<N> segment as the version.
     dated = [m for m in kernel_access.get_metakernels(str(tmpdir), missions='tgo')['data']
              if m['path'].endswith('em16_cassis_v533_20250325_002.tm')][0]
     assert dated['year'] == '20250325'
     assert dated['version'] == 'v533'
-    assert dated['path'].endswith('.tm')
 
 
 def test_get_kernels_from_metakernel_relative_paths(tmpdir, monkeypatch):

--- a/tests/pytests/test_kernel_access.py
+++ b/tests/pytests/test_kernel_access.py
@@ -333,3 +333,71 @@ def test_get_metakernels_search_counts(tmpdir, search_kwargs, expected_count):
 
     search_result =  kernel_access.get_metakernels(str(tmpdir), **search_kwargs)
     assert search_result['count'] == expected_count
+
+def test_get_metakernels_multisegment_filename(tmpdir):
+    """Metakernel names with more segments than mission_year_version must still
+    parse. OSIRIS-REx uses mission_instrument_year_version ('orx_noola_2020_v06');
+    the old positional split mis-parsed these as year='noola', version='2020'.
+    Year is the 4- or 8-digit segment and version the v<N> segment, wherever they
+    appear in the name.
+    """
+    tmpdir.mkdir('orx-b-v01')
+    for year in ('2019', '2020'):
+        for ver in ('v01', 'v06'):
+            open(tmpdir.join('orx-b-v01', f'orx_noola_{year}_{ver}.tm'), 'w').close()
+
+    res = kernel_access.get_metakernels(str(tmpdir), missions='orx',
+                                        years=2020, versions='latest')
+    assert res['count'] == 1
+    assert res['data'][0]['path'].endswith('orx_noola_2020_v06.tm')
+    assert res['data'][0]['year'] == '2020'
+    assert res['data'][0]['version'] == 'v06'
+
+
+def test_get_metakernels_semantic_tgo(tmpdir):
+    """TGO ships semantic metakernels (em16_cassis/ops/plan/flip) plus build-dated
+    variants (em16_cassis_v533_20250325_002.tm). The observation metakernel
+    (em16_cassis) must be selected, not the planning one; the old parser set
+    version='plan' and picked em16_plan via max(). The build-dated variant must
+    parse its 8-digit build date as the year, not leak a filename fragment into
+    the 'path' field.
+    """
+    mk = tmpdir.mkdir('tgo').mkdir('kernels').mkdir('mk')
+    for n in ('em16_cassis', 'em16_ops', 'em16_plan', 'em16_flip',
+              'em16_cassis_v533_20250325_002', 'em16_plan_v533_20250318_001'):
+        open(mk.join(f'{n}.tm'), 'w').close()
+
+    res = kernel_access.get_metakernels(str(tmpdir), missions='tgo',
+                                        years=2018, versions='latest')
+    assert res['count'] == 1
+    assert os.path.basename(res['data'][0]['path']) == 'em16_cassis.tm'
+
+    # the build-dated variant parses without corrupting the path field
+    dated = [m for m in kernel_access.get_metakernels(str(tmpdir), missions='tgo')['data']
+             if m['path'].endswith('em16_cassis_v533_20250325_002.tm')][0]
+    assert dated['year'] == '20250325'
+    assert dated['version'] == 'v533'
+    assert dated['path'].endswith('.tm')
+
+
+def test_get_kernels_from_metakernel_relative_paths(tmpdir, monkeypatch):
+    """A metakernel with relative PATH_VALUES (e.g. '..', as ESA ships) must
+    resolve its kernels against the metakernel's own directory, not the current
+    working directory. Regression: os.path.isfile('../ck/...') was checked
+    relative to CWD and failed unless ALE ran from kernels/mk/.
+    """
+    kroot = tmpdir.mkdir('kernels')
+    mkdir = kroot.mkdir('mk')
+    ckdir = kroot.mkdir('ck')
+    open(ckdir.join('stub.bc'), 'w').close()
+    mk = mkdir.join('test.tm')
+    mk.write("\\begindata\n"
+             "    PATH_VALUES     = ( '..' )\n"
+             "    PATH_SYMBOLS    = ( 'KERNELS' )\n"
+             "    KERNELS_TO_LOAD = ( '$KERNELS/ck/stub.bc' )\n"
+             "\\begintext\n")
+
+    # run from a DIFFERENT directory to prove resolution is anchored to the mk dir
+    monkeypatch.chdir(str(tmpdir.mkdir('elsewhere')))
+    kernels = kernel_access.get_kernels_from_metakernel(str(mk))
+    assert [os.path.realpath(k) for k in kernels] == [os.path.realpath(str(ckdir.join('stub.bc')))]


### PR DESCRIPTION
## Summary

Two related bugs in ale/kernel_access.py prevent isd_generate from producing an ISD out of the box for TGO CaSSIS. The two fixes are logically independent but are submitted together on purpose: the honest end-to-end check of running isd_generate on a real CaSSIS cube only passes when both are fixed, so a single PR is reproducible by a reviewer (see "How to reproduce" below).

## The bugs

### 1. get_metakernels fails to parse metakernel filenames (wrong metakernel selected)

get_metakernels split each metakernel basename positionally into mission_year_version. Any filename with more segments than that gets parsed incorrectly.

- OSIRIS-REx ships orx_noola_2020_v06.tm, with an extra segment "noola" (a kernel-subset designation, not an instrument) between the mission and the year. The positional split produced year='noola', version='2020', so the year filter never matched and versions='latest' picked the wrong file. A full ISISDATA has about 48 of these.
- Rosetta ships ROS_OPS_V350_20220906_001.TM and Mars Express ships MEX_OPS_V324_20250321_001.TM, five segments each, with the same failure.
- TGO ships semantic metakernels (em16_cassis.tm, em16_ops.tm, em16_plan.tm, em16_flip.tm) plus build-dated variants (em16_cassis_v533_20250325_002.tm). With the positional parse the version field became the literal string 'plan', and because max('cassis', 'plan') is 'plan' lexicographically, get_metakernels selected the planning metakernel (em16_plan.tm), which lists predicted kernels not present in the archive, over the observation metakernel (em16_cassis.tm).

Fix: extract year (a 4- or 8-digit YYYY/YYYYMMDD segment) and version (a v<N> segment) by pattern, wherever they occur in the name, then sort the results by year so the latest-version selection groups them correctly. Also skip forecast and planning metakernels (names containing predicted, plan, or flip): they list predicted kernels and are never the right source for an ISD of archived data, so the observation metakernel is chosen (em16_cassis over em16_plan, CH1_V00 over CH1_PREDICTED_V00). Names that already parsed correctly (lro_2013, lro_2013_v01, ch2_v01) are unaffected.

### 2. get_kernels_from_metakernel resolves relative PATH_VALUES against the current directory

ESA metakernels (for example em16_cassis.tm) use a relative PATH_VALUES = ( '..' ), which SPICE resolves against the metakernel's own directory. get_kernels_from_metakernel substituted $KERNELS with '..' and then checked os.path.isfile('../ck/...') relative to the current directory, so every kernel looked "missing" unless ALE happened to be invoked from kernels/mk/, and ISD generation failed with FileNotFoundError. The existing SPICEROOT correction from #703 only rewrites an absolute wrong-root path, it does not handle a relative '..'.

Fix: anchor a relative resolved path to os.path.dirname(metakernel) before the isfile check.

## Effect

With both fixes, isd_generate on a CaSSIS cube finds em16_cassis.tm, furnishes it (relative paths resolved), and writes an ISD with optical_distortion set to cassis, with no --kernel and no hand-built metakernel. Verified against a full ISISDATA.

## Tests

The metakernel lookup lives in NaifSpice.kernels (ale/base/data_naif.py): for any NaifSpice-based driver it calls get_metakernels with the driver's short mission name and the observation year, then get_kernels_from_metakernel on the selected metakernel. This code path is shared by every NaifSpice driver, but it only parses names for a mission that actually ships metakernels (.tm files); a mission without them falls back to SpiceQL and is unaffected by this change. Checking a downloaded ISISDATA and listing the ISIS data remotes, the missions that ship metakernels are Dawn, LRO, MRO, MESSENGER, MSL, TGO, OSIRIS-REx, Mars Express, Rosetta, and Chandrayaan-1 (plus single-file semantic metakernels such as SMART-1). Every one of their name shapes is covered below. Missions such as Cassini, Galileo, Juno, and the Voyagers ship no metakernel and resolve kernels through SpiceQL.

The failure was a parsing problem, so the tests are filename stubs under tmp_path (no SPICE, no kernels, no cube) that exercise the parser directly. test_get_metakernels_all_isisdata_shapes builds one stub per metakernel name shape found across those missions and asserts the correct metakernel is selected. Metakernel names have no formal standard, so the year and version are read by pattern, which makes the parser robust to how many segments a name has.

These shapes are parsed and the right metakernel is selected (one real example each):

- mission_year_version: mro_2005_v08, msgr_2004_v13. The latest version for the observation year is chosen.
- mission_subset_year_version, a 4-segment name: orx_noola_2020_v06. The old positional split mis-read this as year=noola, version=2020.
- mission_body_provider_m<N>_v<N>, no year (Dawn): dawn_ceres_dlr_m135_v1. Parses to year N/A, version v1.
- mission_year, no version: lro_2013.
- mission_year_VERSION, uppercase V: lro_2009_V04.
- mission_version, no year: msl_v01.
- semantic name, no year and no version: MEX_OPS, ROS_OPS, SMART1_OPS, em16_cassis.
- 5-segment build-dated snapshot: MEX_OPS_V324_20250321_001, em16_cassis_v533_20250325_002. The 8-digit build date is read as the year, so a snapshot is filtered out for an older observation year and the generic metakernel is chosen.

These shapes are deliberately skipped, so the observation metakernel is chosen instead:

- predicted: CH1_PREDICTED_V00 is skipped in favor of CH1_V00.
- planning and flip: em16_plan and em16_flip are skipped in favor of em16_cassis.

test_get_kernels_from_metakernel_relative_paths covers the second fix: a relative PATH_VALUES=('..') resolves correctly when ALE is invoked from a different directory.

All test_kernel_access.py tests pass (43 total).

## How to reproduce (offline, with real data)

Requires ISIS + ALE and a full ISISDATA that includes the TGO kernels and metakernels (downloadIsisData tgo $ISISDATA provides $ISISDATA/tgo/kernels/mk/em16_cassis.tm).

    export ISISROOT=<isis conda env>
    export ISISDATA=<path to isisdata>
    export ALESPICEROOT=$ISISDATA

    # 1. Get a CaSSIS PAN product from the ESA PSA (https://archives.esac.esa.int/psa).
    #    Any CaSSIS PAN product works; verified here on the 2018-05-06 framelet below.
    prod=cas_cal_sc_20180506T223500-20180506T223504-2014-16-PAN-272560849-0-0__4_0

    # 2. Ingest the product to an ISIS cube and attach SPICE:
    tgocassis2isis from=$prod.xml to=frame.cub
    # spiceinit needs a recent ISIS with the tgocassis2isis SpacecraftClockStartCount
    # fix for PSA-exported products (DOI-USGS/ISIS3 #6079, recently merged to dev),
    # otherwise spiceinit fails with "Unable to initialize camera model".
    spiceinit      from=frame.cub

    # 3. Generate the CSM ISD out of the box (no -k):
    isd_generate -v frame.cub -o frame.json
    #    frame.json is a complete CaSSIS ISD: instrument_position, instrument_pointing,
    #    and optical_distortion set to cassis (36 coefficients).

Before this PR, step 3 failed with "The frame -143420 is not supported by Naif" and KeyError: 'BODY499_RADII', because em16_plan.tm was selected and/or its relative paths did not resolve.

## Changelog

Added CHANGELOG.md entry.

## Licensing

This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

