### PR TITLE
Add Lagrange interpolation of quaternions to ale::Orientations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ release.
 ## [Unreleased]
 
 ### Added
+- Added order-8 Lagrange interpolation of quaternions to `ale::Orientations`, matching ISIS SpiceRotation, selectable via the new `LAGRANGE_ROTATION` interpolation type. [#726](https://github.com/DOI-USGS/ale/pull/726)
 - Re-enabled and fixed the TGO CaSSIS driver, which now emits the CaSSIS rational distortion. Validated against ISIS to within ~0.013 pixel across 130 framelets of two real stereo pairs. [#720](https://github.com/DOI-USGS/ale/pull/720)
 - `MroHiRisePds3LabelNaifSpiceDriver`, a PDS3 EDR label driver for HiRISE that generates an ISD directly from a raw EDR label without requiring an ISIS cube, paralleling the existing CTX PDS3 driver. [#702](https://github.com/DOI-USGS/ale/pull/702)
 - Added a catch to try correcting paths in metakernels (using spice_root) if they have been left as default. [#703](https://github.com/DOI-USGS/ale/pull/703)

--- a/include/ale/InterpUtils.h
+++ b/include/ale/InterpUtils.h
@@ -12,7 +12,10 @@ namespace ale {
     /// Spherical linear interpolation
     SLERP,
     /// Normalized linear interpolation
-    NLERP
+    NLERP,
+    /// Order-8 Lagrange interpolation of the quaternion components, matching ISIS
+    /// SpiceRotation.
+    LAGRANGE_ROTATION
   };
 
   /// Interpolation enum for defining different methods of interpolating in R

--- a/include/ale/Orientations.h
+++ b/include/ale/Orientations.h
@@ -184,12 +184,39 @@ namespace ale {
      Orientations inverse() const;
 
   private:
+    /**
+     * Interpolate the time dependent rotation at a given time using Lagrange
+     * interpolation of the quaternion components, matching ISIS SpiceRotation.
+     * This reads the sign-continuous quaternion cache (m_quat*), which is built
+     * once when the rotations are set, and renormalizes the interpolated result.
+     *
+     * @param time The time to interpolate at
+     * @param order The order of the Lagrange polynomials to use
+     *
+     * @return The time dependent rotation at the input time
+     */
+    Rotation interpolateTimeDepLagrange(double time, int order=8) const;
+
+    /**
+     * Build the sign-continuous quaternion cache (m_quatW/X/Y/Z) from m_rotations.
+     * Called whenever m_rotations is set.
+     */
+    void computeSignContinuousQuaternions();
+
     std::vector<Rotation> m_rotations; //!< The set of time dependent rotations.
     std::vector<ale::Vec3d> m_avs; //!< The set of angular velocities. Empty if there are no angular velocities.
     std::vector<double> m_times; //!< The set of times
     std::vector<int> m_timeDepFrames; //!< The frame IDs that the time dependent rotations rotate through.
     std::vector<int> m_constFrames; //!< The frame IDs that the constant rotation rotates through.
     Rotation m_constRotation; //!< The constant rotation applied after the time dependent rotations.
+    // Sign-continuous quaternion components (scalar-first: w, x, y, z), one entry per
+    // rotation. These are kept as explicit quaternion components rather than Rotation
+    // objects so that any sign flips between adjacent nodes are resolved once, before
+    // interpolation.
+    std::vector<double> m_quatW;
+    std::vector<double> m_quatX;
+    std::vector<double> m_quatY;
+    std::vector<double> m_quatZ;
   };
 
   /**

--- a/src/Orientations.cpp
+++ b/src/Orientations.cpp
@@ -2,6 +2,8 @@
 
 #include "ale/InterpUtils.h"
 
+#include <cmath>
+
 namespace ale {
 
   Orientations::Orientations(
@@ -21,6 +23,46 @@ namespace ale {
     }
     if ( !m_avs.empty() && (m_avs.size() != m_times.size()) ) {
       throw std::invalid_argument("The number of angular velocities and times must be the same.");
+    }
+    // Compute sign-continuous orientations needed for Lagrange interpolation
+    computeSignContinuousQuaternions();
+  }
+
+  // Compute sign-continuous orientations needed for Lagrange interpolation
+  void Orientations::computeSignContinuousQuaternions() {
+    size_t numRotations = m_rotations.size();
+    m_quatW.resize(numRotations);
+    m_quatX.resize(numRotations);
+    m_quatY.resize(numRotations);
+    m_quatZ.resize(numRotations);
+
+    std::vector<std::vector<double>> quats(numRotations);
+    for (size_t i = 0; i < numRotations; i++) {
+      quats[i] = m_rotations[i].toQuaternion(); // scalar-first w, x, y, z
+    }
+
+    // Find the largest-magnitude quaternion coefficient and its coordinate, and use
+    // its sign as a global reference. This matches ASP's fixQuaternionSigns and is
+    // more robust than propagating from a neighbor: one outlier node cannot flip the
+    // sign of the rest.
+    double maxCoef = 0.0;
+    int maxCoord = 0;
+    for (size_t i = 0; i < numRotations; i++) {
+      for (int j = 0; j < 4; j++) {
+        if (std::abs(quats[i][j]) > std::abs(maxCoef)) {
+          maxCoef = quats[i][j];
+          maxCoord = j;
+        }
+      }
+    }
+
+    // Flip any quaternion whose reference coordinate disagrees in sign.
+    for (size_t i = 0; i < numRotations; i++) {
+      std::vector<double>& q = quats[i];
+      if (q[maxCoord] * maxCoef < 0.0) {
+        q[0] = -q[0]; q[1] = -q[1]; q[2] = -q[2]; q[3] = -q[3];
+      }
+      m_quatW[i] = q[0]; m_quatX[i] = q[1]; m_quatY[i] = q[2]; m_quatZ[i] = q[3];
     }
   }
 
@@ -51,12 +93,31 @@ namespace ale {
     return m_constRotation;
   }
 
+  Rotation Orientations::interpolateTimeDepLagrange(double time, int order) const {
+    // The quaternion components are already sign-continuous (built once by
+    // computeSignContinuousQuaternions when the rotations were set). Interpolate
+    // each component, then renormalize (Lagrange does not preserve the unit norm;
+    // the Rotation constructor does not normalize either, so do it here).
+    double w = lagrangeInterpolate(m_times, m_quatW, time, order);
+    double x = lagrangeInterpolate(m_times, m_quatX, time, order);
+    double y = lagrangeInterpolate(m_times, m_quatY, time, order);
+    double z = lagrangeInterpolate(m_times, m_quatZ, time, order);
+    double norm = std::sqrt(w*w + x*x + y*y + z*z);
+    if (norm == 0.0) {
+      throw std::runtime_error("Lagrange quaternion interpolation produced a zero quaternion.");
+    }
+    return Rotation(w/norm, x/norm, y/norm, z/norm);
+  }
+
   Rotation Orientations::interpolateTimeDep(
     double time,
     RotationInterpolation interpType
   ) const {
     Rotation timeDepRotation;
-    if (m_times.size() > 1) {
+    if (m_times.size() > 1 && interpType == LAGRANGE_ROTATION) {
+      timeDepRotation = interpolateTimeDepLagrange(time);
+    }
+    else if (m_times.size() > 1) {
       int interpIndex = interpolationIndex(m_times, time);
       double t = (time - m_times[interpIndex]) / (m_times[interpIndex + 1] - m_times[interpIndex]);
       timeDepRotation = m_rotations[interpIndex].interpolate(m_rotations[interpIndex + 1], t, interpType);
@@ -158,6 +219,7 @@ namespace ale {
     m_times = mergedTimes;
     m_rotations = mergedRotations;
     m_avs = mergedAvs;
+    computeSignContinuousQuaternions();
 
     return *this;
   }
@@ -177,6 +239,7 @@ namespace ale {
 
     m_rotations = updatedRotations;
     m_avs = updatedAvs;
+    computeSignContinuousQuaternions();
 
     return *this;
   }

--- a/tests/ctests/OrientationsTests.cpp
+++ b/tests/ctests/OrientationsTests.cpp
@@ -154,6 +154,76 @@ TEST_F(OrientationTest, InterpolateAtRotation) {
   EXPECT_NEAR(quat[3], 0.5, 1e-10);
 }
 
+// Fixture for the Lagrange rotation interpolation path. Uses a densely sampled,
+// non-constant-rate rotation about the z axis, theta(t) = sin(t), so that the
+// two-point SLERP leaves a visible error that order-N Lagrange removes.
+class LagrangeOrientationTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+      for (double t = 0.0; t <= 10.0 + 1e-9; t += 0.25) {
+        times.push_back(t);
+        rotations.push_back(truthRot(t));
+      }
+      orientations = Orientations(rotations, times);
+    }
+
+    static Rotation truthRot(double t) {
+      vector<double> axis = {0.0, 0.0, 1.0};
+      return Rotation(axis, sin(t));
+    }
+
+    // Angle in radians between two rotations: 2*acos(|dot of unit quaternions|).
+    static double angleBetween(const Rotation& a, const Rotation& b) {
+      vector<double> qa = a.toQuaternion();
+      vector<double> qb = b.toQuaternion();
+      double dot = fabs(qa[0]*qb[0] + qa[1]*qb[1] + qa[2]*qb[2] + qa[3]*qb[3]);
+      if (dot > 1.0) dot = 1.0;
+      return 2.0 * acos(dot);
+    }
+
+    vector<Rotation> rotations;
+    vector<double> times;
+    Orientations orientations;
+};
+
+TEST_F(LagrangeOrientationTest, ReproducesNodes) {
+  // At a node time, Lagrange must return that node's rotation exactly.
+  double err = angleBetween(orientations.interpolate(5.0, LAGRANGE_ROTATION), truthRot(5.0));
+  EXPECT_LT(err, 1e-9);
+}
+
+TEST_F(LagrangeOrientationTest, MoreAccurateThanSlerp) {
+  // On a non-constant-rate rotation, Lagrange tracks the truth far better than the
+  // two-point SLERP. This is what makes it match ISIS SpiceRotation.
+  double maxLag = 0.0, maxSlerp = 0.0;
+  for (double t = 1.0; t <= 9.0; t += 0.137) {
+    Rotation truth = truthRot(t);
+    double eLag = angleBetween(orientations.interpolate(t, LAGRANGE_ROTATION), truth);
+    double eSlerp = angleBetween(orientations.interpolate(t, SLERP), truth);
+    if (eLag > maxLag) maxLag = eLag;
+    if (eSlerp > maxSlerp) maxSlerp = eSlerp;
+  }
+  EXPECT_LT(maxLag, 1e-5);
+  EXPECT_LT(maxLag, maxSlerp);
+}
+
+TEST_F(LagrangeOrientationTest, SignFlipInvariant) {
+  // Negating alternate input quaternions gives the same rotations. The set-time
+  // sign-continuity fix must make the Lagrange result independent of that.
+  vector<Rotation> flipped;
+  for (size_t i = 0; i < rotations.size(); i++) {
+    vector<double> q = rotations[i].toQuaternion();
+    if (i % 2 == 1) { q[0] = -q[0]; q[1] = -q[1]; q[2] = -q[2]; q[3] = -q[3]; }
+    flipped.push_back(Rotation(q[0], q[1], q[2], q[3]));
+  }
+  Orientations flippedOrientations(flipped, times);
+  for (double t = 1.0; t <= 9.0; t += 0.137) {
+    double d = angleBetween(orientations.interpolate(t, LAGRANGE_ROTATION),
+                            flippedOrientations.interpolate(t, LAGRANGE_ROTATION));
+    EXPECT_LT(d, 1e-6);
+  }
+}
+
 TEST_F(OrientationTest, InterpolateAv) {
   Vec3d interpAv = orientations.interpolateAV(0.25);
   EXPECT_NEAR(interpAv.x, M_PI / (3.0 * sqrt(3.0)), 1e-10);


### PR DESCRIPTION
This adds order-8 Lagrange interpolation of quaternions to ale::Orientations, matching ISIS SpiceRotation. 

ISIS reconstructs sensor pointing between cache nodes with an order-N Lagrange window. When ISIS delegates rotation interpolation to ALE, ale::Orientations reconstructed with a two-node SLERP instead, which is too coarse, and inconsistent with quaternion interpolation in USGSCSM as well.

The orientations are converted to quaternions when set, and made sign-continuous at that time. That is because while a quaternion and its negative represent the same rotation, a sign jump between adjacent nodes gives bad results when interpolating the components with Lagrange. This sign handling has been problematic in the past. 

The existing behavior is unchanged. The new path is off by default and is selected with the LAGRANGE_ROTATION interpolation type. The caller, most likely ISIS, sets that flag to get the Lagrange reconstruction.

Tests are added for exact reproduction at node times, accuracy versus SLERP on a non-constant-rate rotation, and sign-flip invariance.

All tests pass.

Developed with Claude (AI) assistance. The code was thoroughly reviewed. Comments and API were adjusted as needed.

## Questions

This change covers ale::Orientations, which is the interpolation ISIS uses at runtime when it delegates to ALE. 

It is not clear whether anything is also needed on the ISD-generation side, that is, in the Python code. The current default formatter, to_isd, writes the raw pointing table (ephemeris_times and quaternions) straight from the frame chain, without resampling, and USGSCSM does its own Lagrange interpolation of that table when it reads the ISD. 

Could you confirm whether the C++ path here is sufficient, or whether there is a need for this logic in Python as well (a parallel implementation). 

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

