### PR TITLE
Support etsToSclkTicks for CK generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ release.
 ### Changed
 - Reordered the `ale::DistortionType` enum so `RADIAL` and `TRANSVERSE` come in the same order as the matching enum in USGSCSM. The two enums are meant to share integer values (USGSCSM stores the selected type as this integer in the model state), but they had `RADIAL` and `TRANSVERSE` swapped. ALE never serializes this integer, it emits the distortion by name in the ISD, so aligning the ALE order to USGSCSM changes no on-disk data and only removes the mismatch. [#728](https://github.com/DOI-USGS/ale/pull/728)
 - The KPLO ShadowCam driver now subsamples the ephemeris by default (linear reduction, one sample per ~10 lines), as the Chandrayaan-2 driver does, so ISDs for the long ShadowCam strips no longer reach ~20 MB. When the driver defaults the reduction (including when the caller passes `--reduction none`, which cannot be respected for this sensor), it now logs a notice via the ale logger. The Chandrayaan-2 TMC-2 and OHRC drivers, which override the reduction the same way, log the same notice. [#719](https://github.com/DOI-USGS/ale/pull/719)
+- Updated web CK generation in isd_to_kernel to use SpiceQL's `etsToSclkTicks`. [#733](https://github.com/DOI-USGS/ale/pull/733)
 
 ### Fixed
 - `getDistortionModel` now throws on an unrecognized distortion model name in the ISD instead of silently returning `TRANSVERSE`. The silent default applied the wrong distortion, or none, with no warning, and it masked typos and unsupported models. [#728](https://github.com/DOI-USGS/ale/pull/728)

--- a/ale/isd_to_kernel.py
+++ b/ale/isd_to_kernel.py
@@ -392,9 +392,38 @@ def check_env(use_web: bool = False):
         if not cache_dir:
             isisdata = os.environ.get("ISISDATA")
             if not isisdata:
-                raise Exception("ISISDATA and SPICEQL_CACHE_DIR are not set.")
+                raise Exception("ISISDATA is not set. Point ISISDATA to " \
+                                "your local data area.")
             os.environ["SPICEQL_CACHE_DIR"] = isisdata
             logger.info(f"SPICEQL_CACHE_DIR not set; defaulting to ISISDATA [{isisdata}].")
+
+
+def load_isd(isd_file: os.PathLike) -> dict:
+    """
+    Read and parse an ISD JSON file into a dictionary.
+
+    Validates that the file is present and is JSON (by extension and content),
+    raising a clear exception on any failure.
+
+    Parameters
+    ----------
+        isd_file : os.PathLike
+            Path to the input ISD JSON file.
+
+    Returns
+    ----------
+        dict: The parsed ISD contents.
+    """
+    if isd_file is None:
+        raise Exception("Missing ISD file.")
+    if Path(isd_file).suffix != ".json":
+        raise Exception("ISD must be in JSON.")
+    with open(isd_file, "r") as f:
+        contents = f.read()
+    try:
+        return json.loads(contents)
+    except ValueError:
+        raise Exception(f"ISD [{isd_file}] is not valid JSON.")
 
 
 def isd_to_kernel(
@@ -419,12 +448,17 @@ def isd_to_kernel(
     ----------
         isd_file : os.PathLike, optional
             Path to the input ISD JSON file. Required for binary kernels.
+            For text kernels it is optional; when provided, its 'naif_keywords'
+            are written to the kernel.
         kernel_type : str
             The type of kernel to create. Defaults to 'mk'.
         outfile : os.PathLike, optional
             The desired output kernel file name/path.
+            Defaults to ISD filename + kernel extension.
         data : str, optional
-            A JSON string containing keyword-value pairs. Required for text kernels.
+            A JSON string containing keyword-value pairs. For text kernels this
+            is required only when no ISD is provided; when both are given, these
+            keywords are appended after (and override) the ISD's naif_keywords.
         comment : str, optional 
             Custom user text to include in the kernel comment area.
         overwrite : bool
@@ -444,7 +478,8 @@ def isd_to_kernel(
     logger.setLevel(log_level)
 
     # Ensure the environment is set up before any SpiceQL calls are made
-    check_env(use_web)
+    if not use_web and psql.Kernel.isBinary(kernel_type):
+        check_env(use_web)
 
     # Default comment if empty
     if comment is None:
@@ -489,11 +524,7 @@ def isd_to_kernel(
 
     if psql.Kernel.isBinary(kernel_type):
         # Get properties from isd_file
-        with open(isd_file, 'r') as f:
-            isd_data = f.read()
-        
-        # ISD data
-        isd_dict = json.loads(isd_data)
+        isd_dict = load_isd(isd_file)
 
         # Get common properties from ISD
         naif_keywords = isd_dict[ISD_KEY_NAIF_KEYWORDS]
@@ -764,18 +795,34 @@ def isd_to_kernel(
             except ValueError:
                 return False
 
-        if data is None:
-            raise Exception(f"Must enter JSON keywords to generate kernel [{outfile}].")
-        elif not is_valid_json(data):
-            raise Exception("The 'data' payload is not valid JSON.")
-        
-        data = json.loads(data)
+        # Text kernel keywords can come from an ISD's naif_keywords, from the
+        # user-provided data payload, or both. When an ISD is given, its
+        # naif_keywords are used; any user data is appended after (and takes
+        # precedence over) them. When no ISD is given, the user must supply data.
+        keywords = {}
+
+        if isd_file is not None:
+            naif_keywords = load_isd(isd_file).get(ISD_KEY_NAIF_KEYWORDS, {})
+            if not naif_keywords:
+                logger.info(f"ISD [{isd_file}] has no '{ISD_KEY_NAIF_KEYWORDS}' to add.")
+            keywords.update(naif_keywords)
+
+        if data is not None:
+            if not is_valid_json(data):
+                raise Exception("The 'data' payload is not valid JSON.")
+            keywords.update(json.loads(data))
+
+        if not keywords:
+            raise Exception(
+                f"Must provide an ISD with '{ISD_KEY_NAIF_KEYWORDS}' and/or JSON "
+                f"data to generate text kernel [{outfile}]."
+            )
 
         logger.info(f"Generating text kernel type [{kernel_type}]")
         psql.writeTextKernel(
             outfile,
             kernel_type,
-            data,
+            keywords,
             out_comment
         )
     else:

--- a/ale/isd_to_kernel.py
+++ b/ale/isd_to_kernel.py
@@ -750,12 +750,9 @@ def isd_to_kernel(
             # In web mode we do that encoding server-side (etsToSclkTicks) and
             # hand writeCk the pre-encoded ticks so no local data dir is needed.
             ck_times = inst_pt_times
-            times_are_ticks = False
-            if use_web:
-                sc_id = int(inst_frame_code / 1000)
-                ck_times, _ = psql.etsToSclkTicks(sc_id, inst_pt_times, mission_name, True)
-                times_are_ticks = True
-                logger.info(f"Encoded {len(ck_times)} ETs to SCLK ticks via web for sc={sc_id}.")
+            sc_id = int(inst_frame_code / 1000)
+            ck_times, _ = psql.doubleEtsToSclkTicks(sc_id, inst_pt_times, mission_name, use_web)
+            logger.info(f"Encoded {len(ck_times)} ETs to SCLK ticks via web for sc={sc_id}.")
 
             out_comment = ck_comment(
                 outfile=outfile,
@@ -780,11 +777,8 @@ def isd_to_kernel(
                 inst_frame_code,
                 ck_reference_frame,
                 segment_id,
-                sclk_kernels,
-                lsk_kernel,
                 inst_pt_velocities,
-                out_comment,
-                times_are_ticks
+                out_comment
             )
     elif psql.Kernel.isText(kernel_type):
 

--- a/ale/isd_to_kernel.py
+++ b/ale/isd_to_kernel.py
@@ -370,6 +370,33 @@ def ck_comment(outfile: str,
     return ck_comment
 
 
+def check_env(use_web: bool = False):
+    """
+    Checks environment setup for SpiceQL.
+
+    When using the web SpiceQL service, no local SPICE data is required: kernel
+    searching and any ET->SCLK encoding needed to write binary kernels are done
+    server-side.
+
+    When using local data, SpiceQL requires ISISDATA and SPICEQL_CACHE_DIR. ALE
+    defaults SPICEQL_CACHE_DIR to $ISISDATA if it is not already set.
+
+    Parameters
+    -------
+        use_web: bool
+            If True, uses USGS Astrogeology's SpiceQL web service.
+            Defaults to False.
+    """
+    if not use_web:
+        cache_dir = os.environ.get("SPICEQL_CACHE_DIR")
+        if not cache_dir:
+            isisdata = os.environ.get("ISISDATA")
+            if not isisdata:
+                raise Exception("ISISDATA and SPICEQL_CACHE_DIR are not set.")
+            os.environ["SPICEQL_CACHE_DIR"] = isisdata
+            logger.info(f"SPICEQL_CACHE_DIR not set; defaulting to ISISDATA [{isisdata}].")
+
+
 def isd_to_kernel(
     isd_file: os.PathLike = None,
     kernel_type: str = "mk",
@@ -415,6 +442,9 @@ def isd_to_kernel(
     """
     logging.basicConfig(format="%(message)s", level=log_level)
     logger.setLevel(log_level)
+
+    # Ensure the environment is set up before any SpiceQL calls are made
+    check_env(use_web)
 
     # Default comment if empty
     if comment is None:
@@ -684,6 +714,18 @@ def isd_to_kernel(
                 raise Exception(f"Could not find LSK for [{isd_file}].")
             logger.info(f"sclk_kernels={sclk_kernels}, lsk_kernel={lsk_kernel}")
 
+            # Writing a CK requires encoding the ephemeris times to SCLK ticks,
+            # which normally furnishes the SCLK/LSK from a local SPICE data dir.
+            # In web mode we do that encoding server-side (etsToSclkTicks) and
+            # hand writeCk the pre-encoded ticks so no local data dir is needed.
+            ck_times = inst_pt_times
+            times_are_ticks = False
+            if use_web:
+                sc_id = int(inst_frame_code / 1000)
+                ck_times, _ = psql.etsToSclkTicks(sc_id, inst_pt_times, mission_name, True)
+                times_are_ticks = True
+                logger.info(f"Encoded {len(ck_times)} ETs to SCLK ticks via web for sc={sc_id}.")
+
             out_comment = ck_comment(
                 outfile=outfile,
                 segment_id=segment_id,
@@ -699,17 +741,19 @@ def isd_to_kernel(
                 has_av=has_av,
                 kernels=kernels,
                 comment=comment)
+
             psql.writeCk(
                 outfile,
                 inst_pt_quaternions,
-                inst_pt_times,
+                ck_times,
                 inst_frame_code,
                 ck_reference_frame,
                 segment_id,
                 sclk_kernels,
                 lsk_kernel,
                 inst_pt_velocities,
-                out_comment
+                out_comment,
+                times_are_ticks
             )
     elif psql.Kernel.isText(kernel_type):
 

--- a/tests/pytests/test_isd_to_kernel.py
+++ b/tests/pytests/test_isd_to_kernel.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import spiceypy as spice
 
-from ale.isd_to_kernel import isd_to_kernel, spk_comment, ck_comment, main
+from ale.isd_to_kernel import isd_to_kernel, spk_comment, ck_comment, main, load_isd
 from conftest import get_isd, get_isd_path
 from unittest.mock import patch, MagicMock
 
@@ -243,6 +243,96 @@ def test_text_kernel_generation(mock_search, tmp_path):
     assert "TEST_VALUE" in content
 
 
+def test_text_kernel_from_isd(tmp_path):
+    """Text kernel generation uses the ISD's naif_keywords when no data is given."""
+    isd_file = get_isd_path("ctx")
+    naif_keywords = get_isd("ctx")["naif_keywords"]
+
+    outfile = tmp_path / "test.ti"
+    isd_to_kernel(
+        kernel_type="ik",
+        isd_file=isd_file,
+        outfile=outfile
+    )
+
+    assert outfile.exists()
+    content = outfile.read_text()
+    # Every naif_keyword from the ISD should appear in the generated kernel
+    for key in naif_keywords:
+        assert key in content, f"Expected naif_keyword [{key}] in text kernel"
+
+
+def test_text_kernel_isd_and_data(tmp_path):
+    """User-provided data is appended after and overrides the ISD's naif_keywords."""
+    isd_file = get_isd_path("ctx")
+    naif_keywords = get_isd("ctx")["naif_keywords"]
+
+    # Override an existing naif_keyword and add a brand new one
+    override_key = next(iter(naif_keywords))
+    data = json.dumps({override_key: 987654, "MY_EXTRA_KEYWORD": "EXTRA"})
+
+    outfile = tmp_path / "test.ti"
+    isd_to_kernel(
+        kernel_type="ik",
+        isd_file=isd_file,
+        data=data,
+        outfile=outfile
+    )
+
+    assert outfile.exists()
+    content = outfile.read_text()
+    assert "MY_EXTRA_KEYWORD" in content
+    assert "EXTRA" in content
+    # User value overrides the ISD's value for the shared key
+    assert "987654" in content
+    # A non-overridden ISD keyword is still present
+    other_key = [k for k in naif_keywords if k != override_key][0]
+    assert other_key in content
+
+
+def test_text_kernel_no_isd_no_data(tmp_path):
+    """Without an ISD, text kernel generation requires a data payload."""
+    outfile = tmp_path / "test.ti"
+    abs_outfile = str(outfile.resolve())
+
+    expected_msg = (
+        f"Must provide an ISD with 'naif_keywords' and/or JSON data "
+        f"to generate text kernel [{abs_outfile}]."
+    )
+
+    with pytest.raises(Exception, match=re.escape(expected_msg)):
+        isd_to_kernel(kernel_type="ik", outfile=outfile)
+
+
+def test_load_isd_valid():
+    """load_isd returns the parsed ISD dictionary."""
+    isd_dict = load_isd(get_isd_path("ctx"))
+    assert isinstance(isd_dict, dict)
+    assert "naif_keywords" in isd_dict
+
+
+def test_load_isd_none():
+    """load_isd raises when no ISD file is given."""
+    with pytest.raises(Exception, match="Missing ISD file."):
+        load_isd(None)
+
+
+def test_load_isd_bad_extension():
+    """load_isd raises when the file is not a .json file."""
+    with pytest.raises(Exception, match="ISD must be in JSON."):
+        load_isd("test.txt")
+
+
+def test_load_isd_invalid_json(tmp_path):
+    """load_isd raises a clear error when the file is not valid JSON."""
+    bad_isd = tmp_path / "bad.json"
+    bad_isd.write_text("{not valid json")
+
+    expected_msg = f"ISD [{bad_isd}] is not valid JSON."
+    with pytest.raises(Exception, match=re.escape(expected_msg)):
+        load_isd(bad_isd)
+
+
 def test_invalid_isd_extension():
     """Verify that non-JSON files raise an error."""
     expected_msg = "ISD must be in JSON"
@@ -259,12 +349,15 @@ def test_invalid_kernel_type():
 
 
 def test_empty_data(tmp_path):
-    """Verify that text kernels require a data payload."""
+    """Verify that text kernels require an ISD or a data payload."""
     outfile = tmp_path / "test.tf"
-    abs_outfile = str(outfile.resolve()) 
-    
-    expected_msg = f"Must enter JSON keywords to generate kernel [{abs_outfile}]."
-    
+    abs_outfile = str(outfile.resolve())
+
+    expected_msg = (
+        f"Must provide an ISD with 'naif_keywords' and/or JSON data "
+        f"to generate text kernel [{abs_outfile}]."
+    )
+
     with pytest.raises(Exception, match=re.escape(expected_msg)):
         isd_to_kernel(kernel_type="fk", outfile=outfile)
 


### PR DESCRIPTION
[SpiceQL PR that adds `etsToSclkTicks` API function](https://github.com/DOI-USGS/SpiceQL/pull/146)
^Must be merged and released to pass ALE test failures (`writeCk` has wrong number of arguments due to added flag)

For web CK generation, `isd_to_kernel` encodes the ephemeris times to SCLK ticks via `etsToSclkTicks()` and passes them to `writeCk(..., timesAreTicks=True)`, so writeCk no longer has to furnish the SCLK/LSK kernels locally (which requires a SPICE data directory web users don't have).

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

