### PR TITLE
Fix the Cassini ISS drivers so the CSM camera matches ISIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+- Cassini ISS drivers now produce a CSM camera that matches ISIS (cam_test on a NAC image: 0.707 px to ~5e-4 px; the ISIS-SPICE, NAIF-SPICE and PDS3 drivers agree). Fixes:
+  - ISIS-SPICE driver: emit the radial optical distortion (was none).
+  - ISIS-SPICE and NAIF-SPICE drivers: subtract 0.5 from the detector center (ISIS 0.5-based to CSM 0-based).
+  - NAIF-SPICE driver: `focal_length` no longer raises `AttributeError` when `INS_FOCAL_LENGTH` is defined.
+  - NAIF-SPICE driver: `ephemeris_start_time` uses the scalar from `utcToEt` (was a tuple). [#XXXX](https://github.com/DOI-USGS/ale/pull/XXXX)
+
 ## [1.3.0] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,11 @@ release.
 ## [Unreleased]
 
 ### Fixed
-- Cassini ISS drivers now produce a CSM camera that matches ISIS (cam_test on a NAC image: 0.707 px to ~5e-4 px; the ISIS-SPICE, NAIF-SPICE and PDS3 drivers agree). Fixes:
+- Cassini ISS drivers now produce a CSM camera that matches ISIS (ASP cam_test on a NAC image shows the ISIS-SPICE, NAIF-SPICE and PDS3 drivers agree with ISIS to ~5e-4 px). Fixes:
   - ISIS-SPICE driver: emit the radial optical distortion (was none).
   - ISIS-SPICE and NAIF-SPICE drivers: subtract 0.5 from the detector center (ISIS 0.5-based to CSM 0-based).
   - NAIF-SPICE driver: `focal_length` no longer raises `AttributeError` when `INS_FOCAL_LENGTH` is defined.
-  - NAIF-SPICE driver: `ephemeris_start_time` uses the scalar from `utcToEt` (was a tuple). [#XXXX](https://github.com/DOI-USGS/ale/pull/XXXX)
+  - NAIF-SPICE driver: `ephemeris_start_time` uses the scalar from `utcToEt` (was a tuple). [#739](https://github.com/DOI-USGS/ale/pull/739)
 
 ## [1.3.0] - 2026-08-25
 

--- a/ale/drivers/co_drivers.py
+++ b/ale/drivers/co_drivers.py
@@ -183,7 +183,7 @@ class CassiniIssIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, RadialDis
           start time
         """
         if not hasattr(self, "_ephemeris_start_time"):
-            self._ephemeris_start_time = pyspiceql.utcToEt(utc=self.utc_start_time.strftime("%Y-%m-%d %H:%M:%S.%f"), useWeb=self.use_web)
+            self._ephemeris_start_time = pyspiceql.utcToEt(utc=self.utc_start_time.strftime("%Y-%m-%d %H:%M:%S.%f"), useWeb=self.use_web)[0]
         return self._ephemeris_start_time
 
     @property
@@ -222,6 +222,17 @@ class CassiniIssIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, RadialDis
             return [0, float('-8e-6'), 0]
 
     @property
+    def detector_center_line(self):
+        # ISIS uses 0.5-based CCD coordinates (pixel centers at half integers)
+        # while CSM is 0-based. Subtract 0.5 to match the ISIS look direction, as
+        # the LRO, MRO, Dawn, MESSENGER, Kaguya, KPLO and TGO CaSSIS drivers do.
+        return super().detector_center_line - 0.5
+
+    @property
+    def detector_center_sample(self):
+        return super().detector_center_sample - 0.5
+
+    @property
     def focal_length(self):
         """
         NAC uses multiple filter pairs, each filter combination has a different focal length.
@@ -236,13 +247,17 @@ class CassiniIssIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, RadialDis
           except:
             default_focal_len = float(self.naif_keywords['INS{}_FOV_CENTER_PIXEL'.format(self.ikid)][0])
 
-            filters = tuple(self.label["IsisCube"]["BandBin"]['FilterName'].split("/"))
+          # Apply the filter-specific focal length regardless of which branch set
+          # the default above. Previously this block was inside the except, so when
+          # INS_FOCAL_LENGTH was defined (the try succeeded) _focal_length was never
+          # set and the property raised AttributeError.
+          filters = tuple(self.label["IsisCube"]["BandBin"]['FilterName'].split("/"))
 
-            if self.instrument_id == "CASSINI_ISS_NAC":
-                self._focal_length = nac_filter_to_focal_length.get(filters, default_focal_len)
+          if self.instrument_id == "CASSINI_ISS_NAC":
+              self._focal_length = nac_filter_to_focal_length.get(filters, default_focal_len)
 
-            elif self.instrument_id == "CASSINI_ISS_WAC":
-                self._focal_length = wac_filter_to_focal_length.get(filters, default_focal_len)
+          elif self.instrument_id == "CASSINI_ISS_WAC":
+              self._focal_length = wac_filter_to_focal_length.get(filters, default_focal_len)
         return self._focal_length
 
     @property
@@ -771,7 +786,39 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
 
         return self._frame_chain
 
-class CassiniIssIsisLabelIsisSpiceDriver(Framer, IsisLabel, IsisSpice, NoDistortion, Driver):
+class CassiniIssIsisLabelIsisSpiceDriver(Framer, IsisLabel, IsisSpice, RadialDistortion, Driver):
+
+    @property
+    def odtk(self):
+        """
+        The radial distortion coeffs are not defined in the ik kernels, instead
+        they are defined in the ISS Data User Guide (Knowles). Therefore, we
+        manually specify the codes here.
+        Expects instrument_id to be defined. This should be a string containing either
+        CASSINI_ISS_WAC or CASSINI_ISIS_NAC
+
+        Returns
+        -------
+        : list<float>
+          radial distortion coefficients
+        """
+        if self.instrument_id == 'CASSINI_ISS_WAC':
+            # WAC
+            return [0, float('-6.2e-5'), 0]
+        elif self.instrument_id == 'CASSINI_ISS_NAC':
+            # NAC
+            return [0, float('-8e-6'), 0]
+
+    @property
+    def detector_center_line(self):
+        # ISIS uses 0.5-based CCD coordinates (pixel centers at half integers)
+        # while CSM is 0-based. Subtract 0.5 to match the ISIS look direction, as
+        # the LRO, MRO, Dawn, MESSENGER, Kaguya, KPLO and TGO CaSSIS drivers do.
+        return super().detector_center_line - 0.5
+
+    @property
+    def detector_center_sample(self):
+        return super().detector_center_sample - 0.5
 
     @property
     def instrument_id(self):

--- a/ale/drivers/co_drivers.py
+++ b/ale/drivers/co_drivers.py
@@ -223,9 +223,7 @@ class CassiniIssIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, RadialDis
 
     @property
     def detector_center_line(self):
-        # ISIS uses 0.5-based CCD coordinates (pixel centers at half integers)
-        # while CSM is 0-based. Subtract 0.5 to match the ISIS look direction, as
-        # the LRO, MRO, Dawn, MESSENGER, Kaguya, KPLO and TGO CaSSIS drivers do.
+        # ISIS CCD coordinates are 0.5-based (pixel centers at half integers); CSM is 0-based.
         return super().detector_center_line - 0.5
 
     @property
@@ -247,10 +245,7 @@ class CassiniIssIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, RadialDis
           except:
             default_focal_len = float(self.naif_keywords['INS{}_FOV_CENTER_PIXEL'.format(self.ikid)][0])
 
-          # Apply the filter-specific focal length regardless of which branch set
-          # the default above. Previously this block was inside the except, so when
-          # INS_FOCAL_LENGTH was defined (the try succeeded) _focal_length was never
-          # set and the property raised AttributeError.
+          # Apply the filter-specific focal length.
           filters = tuple(self.label["IsisCube"]["BandBin"]['FilterName'].split("/"))
 
           if self.instrument_id == "CASSINI_ISS_NAC":
@@ -811,9 +806,7 @@ class CassiniIssIsisLabelIsisSpiceDriver(Framer, IsisLabel, IsisSpice, RadialDis
 
     @property
     def detector_center_line(self):
-        # ISIS uses 0.5-based CCD coordinates (pixel centers at half integers)
-        # while CSM is 0-based. Subtract 0.5 to match the ISIS look direction, as
-        # the LRO, MRO, Dawn, MESSENGER, Kaguya, KPLO and TGO CaSSIS drivers do.
+        # ISIS CCD coordinates are 0.5-based (pixel centers at half integers); CSM is 0-based.
         return super().detector_center_line - 0.5
 
     @property

--- a/tests/pytests/data/isds/cassiniiss_isis_isd.json
+++ b/tests/pytests/data/isds/cassiniiss_isis_isd.json
@@ -128,8 +128,8 @@
     "focal_length": 2003.09
   },
   "detector_center": {
-    "line": 512.5,
-    "sample": 512.5
+    "line": 512.0,
+    "sample": 512.0
   },
   "starting_detector_line": 0,
   "starting_detector_sample": 0,
@@ -147,7 +147,7 @@
     "radial": {
       "coefficients": [
         0.0,
-        0.0,
+        -8e-06,
         0.0
       ]
     }

--- a/tests/pytests/test_cassini_drivers.py
+++ b/tests/pytests/test_cassini_drivers.py
@@ -199,16 +199,12 @@ class test_cassini_iss_isis_naif(unittest.TestCase):
             assert self.driver.focal_length == 2003.09
 
     def test_focal_length_with_ins_focal_length(self):
-        # Regression: when INS_FOCAL_LENGTH is defined the try branch succeeds; the
-        # focal length must still resolve (previously _focal_length was left unset
-        # in that case, raising AttributeError).
+        # focal_length resolves when INS_FOCAL_LENGTH is defined.
         with patch.object(CassiniIssIsisLabelNaifSpiceDriver, 'naif_keywords', new_callable=PropertyMock) as naif_keywords_call, \
              patch.object(CassiniIssIsisLabelNaifSpiceDriver, 'ikid', new_callable=PropertyMock) as ikid_call:
             naif_keywords_call.return_value = {"INS-12345_FOCAL_LENGTH": 2000.0}
             ikid_call.return_value = -12345
-            # The CL1/UV3 filter is in the lookup table, so its focal length is
-            # returned; the point is that this resolves at all (no AttributeError)
-            # now that INS_FOCAL_LENGTH is defined and the try branch succeeds.
+            # CL1/UV3 is in the lookup table, so its focal length is returned.
             assert self.driver.focal_length == 2003.09
 
     def test_sensor_model_version(self):

--- a/tests/pytests/test_cassini_drivers.py
+++ b/tests/pytests/test_cassini_drivers.py
@@ -175,13 +175,13 @@ class test_cassini_iss_isis_naif(unittest.TestCase):
         assert self.driver.sensor_name == "Imaging Science Subsystem Narrow Angle Camera"
 
     def test_ephemeris_start_time(self):
-        with patch('ale.drivers.co_drivers.pyspiceql.utcToEt', side_effect=[12345]) as utcToEt:
+        with patch('ale.drivers.co_drivers.pyspiceql.utcToEt', side_effect=[(12345, 0)]) as utcToEt:
             assert self.driver.ephemeris_start_time == 12345
             calls = [call(utc='2011-12-12 05:02:19.773000', useWeb=False)]
             utcToEt.assert_has_calls(calls)
 
     def test_center_ephemeris_time(self):
-        with patch('ale.drivers.co_drivers.pyspiceql.utcToEt', side_effect=[12345]) as utcToEt:
+        with patch('ale.drivers.co_drivers.pyspiceql.utcToEt', side_effect=[(12345, 0)]) as utcToEt:
             assert self.driver.center_ephemeris_time == 12347.3
             calls = [call(utc='2011-12-12 05:02:19.773000', useWeb=False)]
             utcToEt.assert_has_calls(calls)
@@ -196,6 +196,19 @@ class test_cassini_iss_isis_naif(unittest.TestCase):
              patch.object(CassiniIssIsisLabelNaifSpiceDriver, 'ikid', new_callable=PropertyMock) as ikid_call:
             naif_keywords_call.return_value = {"INS-12345_FOV_CENTER_PIXEL": [2003.09]}
             ikid_call.return_value = -12345
+            assert self.driver.focal_length == 2003.09
+
+    def test_focal_length_with_ins_focal_length(self):
+        # Regression: when INS_FOCAL_LENGTH is defined the try branch succeeds; the
+        # focal length must still resolve (previously _focal_length was left unset
+        # in that case, raising AttributeError).
+        with patch.object(CassiniIssIsisLabelNaifSpiceDriver, 'naif_keywords', new_callable=PropertyMock) as naif_keywords_call, \
+             patch.object(CassiniIssIsisLabelNaifSpiceDriver, 'ikid', new_callable=PropertyMock) as ikid_call:
+            naif_keywords_call.return_value = {"INS-12345_FOCAL_LENGTH": 2000.0}
+            ikid_call.return_value = -12345
+            # The CL1/UV3 filter is in the lookup table, so its focal length is
+            # returned; the point is that this resolves at all (no AttributeError)
+            # now that INS_FOCAL_LENGTH is defined and the try branch succeeds.
             assert self.driver.focal_length == 2003.09
 
     def test_sensor_model_version(self):


### PR DESCRIPTION
Made the three Cassini ISS drivers produce a CSM camera that matches the ISIS camera:

- ISIS-SPICE driver: emit the radial optical distortion (was none).
- ISIS-SPICE and NAIF-SPICE drivers: subtract 0.5 from the detector center (ISIS 0.5-based to CSM 0-based).
- NAIF-SPICE focal_length: no longer raises AttributeError when INS_FOCAL_LENGTH is defined.
- NAIF-SPICE ephemeris_start_time: take the scalar from utcToEt (was a tuple).

Validated against ISIS with cam_test on a Cassini NAC image. The pixel error is 5e-4 pixel.  

The ISIS-SPICE, NAIF-SPICE and PDS3 drivers now agree with each other and with ISIS. 

Updated the ISIS-SPICE golden ISD and the ephemeris unit tests, and added a focal_length regression test. USGSCSM needs no change.

Developed with assistance from Claude (AI).

This was manually edited for readability.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

